### PR TITLE
Added argument option disable-backlog

### DIFF
--- a/bin/move_it_server.py
+++ b/bin/move_it_server.py
@@ -135,6 +135,9 @@ if __name__ == '__main__':
     parser.add_argument("-p", "--port",
                         help="The port to publish on. 9010 is the default",
                         default=9010)
+    parser.add_argument("--disable-backlog",
+                        help="Disable globing and handeling of backlog of files at start/restart",
+                        action='store_true')
     cmd_args = parser.parse_args()
 
     log_format = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
@@ -168,8 +171,8 @@ if __name__ == '__main__':
             pyinotify.IN_CREATE)
     watchman = pyinotify.WatchManager()
 
-    def reload_cfg_file(filename):
-        return reload_config(filename, chains, publisher=PUB)
+    def reload_cfg_file(filename, disable_backlog=False):
+        return reload_config(filename, chains, publisher=PUB, disable_backlog=disable_backlog)
 
     notifier = pyinotify.ThreadedNotifier(watchman, EventHandler(
         reload_cfg_file, cmd_filename=cmd_args.config_file))
@@ -191,7 +194,7 @@ if __name__ == '__main__':
     notifier.start()
 
     try:
-        reload_cfg_file(cmd_args.config_file)
+        reload_cfg_file(cmd_args.config_file, disable_backlog=cmd_args.disable_backlog)
         main()
     except KeyboardInterrupt:
         LOGGER.debug("Interrupting")

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -357,7 +357,8 @@ def reload_config(filename,
                   chains,
                   notifier_builder=create_notifier,
                   manager=RequestManager,
-                  publisher=None):
+                  publisher=None,
+                  disable_backlog=False):
     """Rebuild chains if needed (if the configuration changed) from *filename*.
     """
 
@@ -413,7 +414,7 @@ def reload_config(filename,
         LOGGER.debug("Removed " + key)
 
     LOGGER.debug("Reloaded config from " + filename)
-    if old_glob:
+    if old_glob and not disable_backlog:
         time.sleep(3)
         for pattern, fun in old_glob:
             process_old_files(pattern, fun)


### PR DESCRIPTION
This turn off publishing of files on disk at startup/restart. This can be usefull to avoid a lot of old files published at startup

I have only put this disable-backlog at startup. At reload from signal or inotify event don't apply this flag