### PR TITLE
Fix error handling for client unpacking

### DIFF
--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -192,10 +192,12 @@ class Listener(Thread):
 def unpack_tar(filename, delete=False):
     """Unpack tar files."""
     destdir = os.path.dirname(filename)
-    with tarfile.open(filename) as tar:
-        tar.extractall(destdir)
-        members = tar.getmembers()
-
+    try:
+        with tarfile.open(filename) as tar:
+            tar.extractall(destdir)
+            members = tar.getmembers()
+    except tarfile.ReadError as err:
+        raise IOError(str(err))
     if delete:
         os.remove(filename)
     return (member.name for member in members)
@@ -336,7 +338,11 @@ def request_push(msg, destination, login, publisher=None, unpack=None, delete=Fa
             for uid in gen_dict_extract(msg.data, 'uid'):
                 file_cache.append(uid)
 
-        lmsg = unpack_and_create_local_message(response, local_dir, unpack, delete)
+        try:
+            lmsg = unpack_and_create_local_message(response, local_dir, unpack, delete)
+        except IOError:
+            LOGGER.exception("Couldn't unpack %s", str(response))
+            return
         if publisher:
             lmsg = make_uris(lmsg, destination, login)
             lmsg.data['origin'] = response.data['request_address']


### PR DESCRIPTION
When the unpacking goes wrong, the error isn't being catched, leading to dire effects