### PR TITLE
Add polling scan from server, xrit unpack on client and other minor features

### DIFF
--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -106,7 +106,7 @@ Others configuration values:
                  reference file content:
                                           [REF]
                                           SourcePath = referenced_directory_contains_unpacked_data
-                                          FileName = name_of_ref_file
+                                          FileName = file that triggered generation of ref file
 
 
 Logging

--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -56,6 +56,14 @@ For example::
   topic=/1b/hrit/zds
   publish_port=0
 
+  destination_subdir=%Y%m%d%H%M
+  destination_size=20
+  unpack=xrit
+  unpack_prog=/path/to/xRITDecompress64
+  procfile_log=/directory/you/want/processed_file_log.log
+  procfile_log_size=22000
+  use_ref_file=/the/directory/you/want/save/reference/file
+
 * 'provider' is the address of the server receiving the data you want.
 
 * 'destinations' is the list of places to put the unpacked data in.
@@ -63,6 +71,43 @@ For example::
 * 'topic' gives the topic to listen to on the provider side.
 
 * 'publish_port' defines on which port to publish incomming files. 0 means random port.
+
+Others configuration values:
+
+* 'destination_subdir' subdirectory inside 'destination' in which you want the unpacked data.
+                       special strftime function is applied to destination_subdir
+
+* 'destination_size' maximum number of destination subdirs can be created under destinations
+
+*  'unpack' is the compression type of files.
+            Add unpack also to move client if you want to perform unpack function on client side
+*  'unpack_prog' program used to unpack data
+
+    .. note:: The 'xrit' unpacking function is dependent on a program that can
+    unpack xRIT files. Such a program is available from the `Eumetsat.int
+    <http://www.eumetsat.int/Home/Main/DataAccess/SupportSoftwareTools/index.htm?l=en>`_
+    website.
+
+* 'procfile_log' [optional] path and name of procfile log.
+                 If defined a log is saved in filesystem, containing all the data processed by the client
+                 in order to avoid client process same files multiple times.
+                 If client and server have been restarded, procfile_log is used to detect data already processed
+
+* 'procfile_log_size' [optional] maximum number of files saved in the 'procfile_log' file
+
+* 'use_ref_file' [optional] Path where generate reference files.
+                 If defined, a reference file is generated in the specified path when an epilogue segment is processed.
+
+                 Reference file means that an epilogue has been processed for the referenced directory,
+                 referenced directory is the directory where unpacked data are stored.
+                 ref_file can be used to retrigger processing or just to monitor completion of received segments.
+
+                 reference file name: name of the epilogue segment
+                 reference file content:
+                                          [REF]
+                                          SourcePath = referenced_directory_contains_unpacked_data
+                                          FileName = name_of_ref_file
+
 
 Logging
 -------

--- a/bin/move_it_server.py
+++ b/bin/move_it_server.py
@@ -59,6 +59,7 @@ For example::
   info=sensor=seviri;sublon=0
   request_port=9092
   working_directory=/tmp/unpacked
+  origin_scanmode=polling
 
 * 'origin' is the directory and pattern of files to watch for. For a description
   of the pattern format, see the trollsift documentation:
@@ -81,6 +82,10 @@ For example::
 
 * 'topic', 'publish_port', and 'info' define the messaging behaviour using posttroll. 'info' being a ';' separated
   list of 'key=value' items that has to be added to the message info.
+
+* 'origin_scanmode' [optional] Available value: "polling".
+                               If defined as "polling" server uses polling to scan directories instead of pynotify
+
 
 Logging
 -------

--- a/examples/move_it_client_optional-values.ini
+++ b/examples/move_it_client_optional-values.ini
@@ -1,0 +1,35 @@
+# Start with e.g.
+# move_it_client.py -v move_it_client.ini
+
+[eumetcast_hrit]
+# Servers to listen, <server>:<port>
+# Use the port number defined with the -p flag for server or mirror
+providers=localhost:9010
+# Local destination where unpack data
+destination=/local/path/where/save_data
+# Topic to follow
+topic=/eumetcast_hrit/topic/alias
+# Port for file requests: 0 = random
+publish_port=0
+login=username:password
+
+
+### Optional values:
+
+# xrit decompression done by client
+unpack=xrit
+# location of program to unpack data
+unpack_prog=/path/to/xRITDecompress64
+
+# YYYMMDD subdirector, inside 'destination', where save the unpacked data
+destination_subdir=%Y%m%d%H%M
+# Max number of destination subdirectories
+destination_size=20
+
+# Log file to save processed data and avoid reprocessing of segments
+procfile_log=/path/to/processed_data.log
+# Max number of files to save in procfile_log. If not specified default value will be used
+procfile_log_size=22000
+
+# Local path where save reference files
+use_ref_file=/path/to/reference_files

--- a/examples/move_it_client_optional-values.ini
+++ b/examples/move_it_client_optional-values.ini
@@ -31,5 +31,9 @@ procfile_log=/path/to/processed_data.log
 # Max number of files to save in procfile_log. If not specified default value will be used
 procfile_log_size=22000
 
-# Local path where save reference files
-use_ref_file=/path/to/reference_files
+# REF Filename pattern. Wildcards are replaced with the info of segment that triggers the ref file generation
+use_ref_file=/pat/to/ref/H-REF-000-{series:_<6s}-{platform_name:4s}________-_________-{segment:_<9s}-{nominal_time:%Y%m%d%H%M}-__
+
+# optional - name pattern of segments from which extract information for the ref filename
+# default: H-000-{series:_<6s}-{platform_name:4s}________-{channel:_<9s}-{segment:_<9s}-{nominal_time:%Y%m%d%H%M}-{compress_flag:_<1s}_
+ref_segment_pattern=H-000-{series:_<6s}-{platform_name:4s}________-{channel:_<9s}-{segment:_<9s}-{nominal_time:%Y%m%d%H%M}-{compress_flag:_<1s}_

--- a/examples/move_it_server_optional-values.ini
+++ b/examples/move_it_server_optional-values.ini
@@ -1,0 +1,27 @@
+[eumetcast_hrit]
+origin=/local/disk/received/H-000-{series:_<6s}-MSG4________-{channel:_<9s}-{segment:_<9s}-{nominal_time:%Y%m%d%H%M}-{compress_flag:_<1s}_
+# The port to which clients send their requests
+request_port=9092
+# Port used to publish new data
+publish_port=9010
+# Additional metadata about the data
+info=sensors=seviri;stream=eumetcast
+# Advertise the data with this topic
+topic = /eumetcast/topic/alias
+# If data are compressed, uncomment following
+# Decompress the data before sending into this directory
+# working_directory = /local_disk/eumetcast/received/unpacked/
+# The name of the compression function in Python
+# compression = xrit
+# Program actually used in decompression
+# prog = /local_disk/eumetcast/opt/move_it/bin/xRITDecompress
+# Do not delete the compressed file
+delete = False
+
+### Optional values:
+
+# Use polling to check for new files
+origin_scanmode=polling
+
+
+

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -41,6 +41,8 @@ from posttroll.message import Message, MessageError
 from posttroll.publisher import NoisyPublisher
 from posttroll.subscriber import Subscriber
 
+from trollsift import globify, parse
+
 from trollmoves import heartbeat_monitor
 from trollmoves.utils import get_local_ips
 from trollmoves.utils import gen_dict_extract, translate_dict, translate_dict_value
@@ -309,7 +311,7 @@ def generate_ref_file(msg, destination, ref_file_dir):
             destination (string): destination path of the file in processing
             ref_file_dir (string): directory in which reference file should be created
     """
-    ref_file = ref_file_dir + "/" + msg.data['uid']
+    ref_file = ref_file_dir + "/REF-" + msg.data['uid']
     LOGGER.debug("Generating reference file: " + ref_file)
     generate_ref(destination, msg.data['uid'], ref_file)
 

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -208,29 +208,29 @@ def generate_ref(dest_dir, filename, ref_file):
             dest_dir: string
                 referenced directory (where satellite data are stored/decompressed)
             filename: string
-                reference file name
+                referenced file name
             ref_file: string
                 reference file full path
     """
     dest_epistr = "[REF]\r\n"
     dest_epistr += "SourcePath = " + dest_dir + "\r\n"
     dest_epistr += "FileName = " + filename + "\r\n"
-    dest_epifilefp = open(ref_file, "w")
+    dest_epifilefp = open(str(ref_file), "w")
     dest_epifilefp.write(dest_epistr)
     dest_epifilefp.close()
     return ref_file
 
-def trigger_ref(dest_dir, ref_dir):
+def trigger_ref(dest_dir, ref_filename):
     """ Trigger reference file: only if epilogue segment is present in data
 
         Args:
             dest_dir (string): referenced directory - where satellite data are stored/decompressed
-            ref_dir (string): directory where reference file is saved
+            ref_filename (string): filename and path of the ref file
     """
     dest_epifile = None
     for fname in os.listdir(dest_dir):
         if fname.find("-EPI")>0:
-            dest_epifile = ref_dir + "/REF-" + fname
+            dest_epifile = ref_filename
             dest_file = fname
             break
     if dest_epifile is not None:
@@ -238,7 +238,6 @@ def trigger_ref(dest_dir, ref_dir):
             #touch the ref file
             LOGGER.debug("Retrigger reference file: " + dest_epifile)
             os.remove(dest_epifile)
-            ref_filename = ref_dir + "/REF-" + dest_file
             generate_ref(dest_dir, dest_file, ref_filename)
 
 

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -230,7 +230,7 @@ def trigger_ref(dest_dir, ref_dir):
     dest_epifile = None
     for fname in os.listdir(dest_dir):
         if fname.find("-EPI")>0:
-            dest_epifile = ref_dir + "/" + fname
+            dest_epifile = ref_dir + "/REF-" + fname
             dest_file = fname
             break
     if dest_epifile is not None:
@@ -238,7 +238,7 @@ def trigger_ref(dest_dir, ref_dir):
             #touch the ref file
             LOGGER.debug("Retrigger reference file: " + dest_epifile)
             os.remove(dest_epifile)
-            ref_filename = ref_dir + "/" + dest_file
+            ref_filename = ref_dir + "/REF-" + dest_file
             generate_ref(dest_dir, dest_file, ref_filename)
 
 

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -21,30 +21,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import netifaces
 import bz2
-import errno
-import fnmatch
-import glob
 import logging
 import logging.handlers
 import os
 import shutil
 import subprocess
-import sys
-import time
 import traceback
-from ConfigParser import ConfigParser
-from ftplib import FTP, all_errors
-from Queue import Empty, Queue
-from threading import Thread
 from urlparse import urlparse, urlunparse
-
-import pyinotify
-from zmq import NOBLOCK, POLLIN, PULL, PUSH, ROUTER, Poller, ZMQError
-
-from posttroll import context
-from posttroll.message import Message
-from posttroll.publisher import get_own_ip
-from trollsift import globify, parse
 
 
 LOGGER = logging.getLogger(__name__)

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -20,7 +20,34 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import netifaces
+import bz2
+import errno
+import fnmatch
+import glob
+import logging
+import logging.handlers
+import os
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+from ConfigParser import ConfigParser
+from ftplib import FTP, all_errors
+from Queue import Empty, Queue
+from threading import Thread
+from urlparse import urlparse, urlunparse
 
+import pyinotify
+from zmq import NOBLOCK, POLLIN, PULL, PUSH, ROUTER, Poller, ZMQError
+
+from posttroll import context
+from posttroll.message import Message
+from posttroll.publisher import get_own_ip
+from trollsift import globify, parse
+
+
+LOGGER = logging.getLogger(__name__)
 
 def get_local_ips():
     """Get the ips of the current machine."""
@@ -105,3 +132,136 @@ def translate_dict(var, keys, callback):
         return newvar
     else:
         return var
+
+
+def check_output(*popenargs, **kwargs):
+    """Copy from python 2.7, `subprocess.check_output`."""
+    if 'stdout' in kwargs:
+        raise ValueError('stdout argument not allowed, it will be overridden.')
+    LOGGER.debug("Calling " + str(popenargs))
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    del unused_err
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        raise RuntimeError(output)
+    return output
+
+def xrit(pathname, destination=None, cmd="./xRITDecompress"):
+    """Unpacks xrit data."""
+    opath, ofile = os.path.split(pathname)
+    destination = destination or "/tmp/"
+    dest_url = urlparse(destination)
+    expected = os.path.join((destination or opath), ofile[:-2] + "__")
+    if dest_url.scheme in ("", "file"):
+        if ofile != os.path.basename(expected):
+           check_output([cmd, pathname], cwd=(destination or opath))
+    else:
+        LOGGER.exception("Can not extract file " + pathname + " to " +
+                         destination + ", destination has to be local.")
+    LOGGER.info("Successfully extracted " + pathname + " to " + destination)
+    return expected
+
+
+# bzip
+BLOCK_SIZE = 1024
+def bzip(origin, destination=None):
+    """Unzip files."""
+    ofile = os.path.split(origin)[1]
+    destfile = os.path.join(destination or "/tmp/", ofile[:-4])
+    if os.path.exists(destfile):
+        return destfile
+    with open(destfile, "wb") as dest:
+        try:
+            orig = bz2.BZ2File(origin, "r")
+            while True:
+                block = orig.read(BLOCK_SIZE)
+
+                if not block:
+                    break
+                dest.write(block)
+            LOGGER.debug("Bunzipped " + origin + " to " + destfile)
+        finally:
+            orig.close()
+    return destfile
+
+def purge_dir(dir_base, destination_size):
+    """ Purge older subdirectories
+
+        Args:
+            dir_base (string): base directory in which subdirectories are generated
+            destination_size (int): maximum number of subdirectories
+
+        Returns:
+            deleted_count (int): number of deleted subdirectories
+    """
+    deleted_count = 0
+    dest_list = os.listdir(dir_base)
+    dest_listsubdir = []
+    for dest_dir in dest_list:
+        if os.path.isdir(os.path.join(dir_base, dest_dir)):
+            dest_listsubdir.append(dest_dir)
+    LOGGER.debug("Purging subdir: dir found " + str(len(dest_listsubdir)) + " max size " + str(destination_size))
+    if len(dest_listsubdir) > destination_size:
+        # Number of subdirs exceeding maximum size
+        dest_listsubdir.sort()
+        dest_todel = len(dest_listsubdir) - destination_size
+        for x in range(0, dest_todel):
+            dest_dirtodel = os.path.join(dir_base, dest_listsubdir[x])
+            LOGGER.debug("Purging subdir - deleting " + str(dest_dirtodel))
+            shutil.rmtree(dest_dirtodel)
+            deleted_count += 1
+    else:
+        LOGGER.debug("Purging subdir: No dir to purge")
+    return deleted_count
+
+def generate_ref(dest_dir, filename, ref_file):
+    """ Generate reference file
+
+        Args:
+            dest_dir: string
+                referenced directory (where satellite data are stored/decompressed)
+            filename: string
+                reference file name
+            ref_file: string
+                reference file full path
+    """
+    dest_epistr = "[REF]\r\n"
+    dest_epistr += "SourcePath = " + dest_dir + "\r\n"
+    dest_epistr += "FileName = " + filename + "\r\n"
+    dest_epifilefp = open(ref_file, "w")
+    dest_epifilefp.write(dest_epistr)
+    dest_epifilefp.close()
+    return ref_file
+
+def trigger_ref(dest_dir, ref_dir):
+    """ Trigger reference file: only if epilogue segment is present in data
+
+        Args:
+            dest_dir (string): referenced directory - where satellite data are stored/decompressed
+            ref_dir (string): directory where reference file is saved
+    """
+    dest_epifile = None
+    for fname in os.listdir(dest_dir):
+        if fname.find("-EPI")>0:
+            dest_epifile = ref_dir + "/" + fname
+            dest_file = fname
+            break
+    if dest_epifile is not None:
+        if os.path.isfile(dest_epifile):
+            #touch the ref file
+            LOGGER.debug("Retrigger reference file: " + dest_epifile)
+            os.remove(dest_epifile)
+            ref_filename = ref_dir + "/" + dest_file
+            generate_ref(dest_dir, dest_file, ref_filename)
+
+
+def is_epilogue(filename):
+    """ Check if filename is an epilogue segment
+    """
+    if filename.find("-EPI") > 0:
+        return True
+    return False


### PR DESCRIPTION
Some new features added:

Client:
- xrit decompression can be executed by the client.
xrit functions have been moved from server to utils.py script since they are used also from the client.
- reference file mode: if configured, generate a reference file (REF file) when a complete set of data is processed. The REF file is a text file containing information on where the complete set of data has been decompressed.
- procfile_log: generation of a log file containing the leatest segments processed by the client. Used to avoid reprocessing of old data.

Server:
- Add new polling scanmode: if configure, polling mode is used to detect new files instead of pynotify

Documentation:
- Update docstring with the new configurable parameters
- Add two example config files containing the new parameters

