### PR TITLE
Add "nameservers" option to trollmoves client

### DIFF
--- a/examples/move_it_client.ini
+++ b/examples/move_it_client.ini
@@ -14,6 +14,8 @@ login = user:pass
 topic = /1b/hrit-segment/0deg
 # Port for file requests: 0 = random
 publish_port = 0
+# Disable multicasting and use direct nameserver connections
+nameservers = localhost 192.168.0.10 192.168.0.11
 
 # Example using SSH/SCP transfer
 [eumetcast_hrit_0deg_scp]

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -74,6 +74,7 @@ def read_config(filename):
         res[section].setdefault("heartbeat", True)
         res[section].setdefault("req_timeout", DEFAULT_REQ_TIMEOUT)
         res[section].setdefault("transfer_req_timeout", 10 * DEFAULT_REQ_TIMEOUT)
+        res[section].setdefault("nameservers", None)
         if res[section]["heartbeat"] in ["", "False", "false", "0", "off"]:
             res[section]["heartbeat"] = False
 
@@ -388,8 +389,13 @@ def reload_config(filename, chains, callback=request_push, pub_instance=None):
 
         chains[key] = val
         try:
-            chains[key]["publisher"] = NoisyPublisher("move_it_" + key,
-                                                      val["publish_port"])
+            nameservers = val["nameservers"]
+            if nameservers:
+                nameservers = nameservers.split()
+            chains[key]["publisher"] = NoisyPublisher(
+                "move_it_" + key,
+                port=val["publish_port"],
+                nameservers=nameservers)
         except (KeyError, NameError):
             pass
 


### PR DESCRIPTION
This PR adds support to direct nameserver connections for cases where multicast is not available.
