### PR TITLE
Make it possible to provide per-provider topic

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,5 @@
+linters:
+  flake8:
+    fixer: true
+fixers:
+  enable: true

--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -106,15 +106,19 @@ class Listeners(object):
     def __init__(self, callback, client_topic, providers, **attrs):
         self.listeners = []
         if client_topic is None:
-            topics = []
+            client_topic = []
         else:
-            topics = [client_topic]
+            client_topic = [client_topic]
+
         for provider in providers.split():
+            topic = client_topic
             if '/' in provider:
                 parts = provider.split('/', 1)
                 provider = parts[0]
-                topics.append('/' + parts[1])
-            self.listeners.append(Listener('tcp://' + provider, topics,
+                topic = ['/' + parts[1]]
+                LOGGER.info("Using provider-specific topic %s for %s"
+                            topic, provider)
+            self.listeners.append(Listener('tcp://' + provider, topic,
                                            callback, **attrs))
 
     def start(self):

--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -90,6 +90,8 @@ class MoveItMirror(MoveItBase):
             LOGGER.debug('Sending %s', str(new_msg))
             send(str(new_msg))
 
+        if "client_topic" not in attrs:
+            attrs["client_topic"] = None
         listeners = Listeners(publish_callback, **attrs)
 
         return listeners, foo
@@ -103,8 +105,16 @@ class Listeners(object):
 
     def __init__(self, callback, client_topic, providers, **attrs):
         self.listeners = []
+        if client_topic is None:
+            topics = []
+        else:
+            topics = [client_topic]
         for provider in providers.split():
-            self.listeners.append(Listener('tcp://' + provider, [client_topic],
+            if '/' in provider:
+                parts = provider.split('/', 1)
+                provider = parts[0]
+                topics.append('/' + parts[1])
+            self.listeners.append(Listener('tcp://' + provider, topics,
                                            callback, **attrs))
 
     def start(self):

--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -116,7 +116,7 @@ class Listeners(object):
                 parts = provider.split('/', 1)
                 provider = parts[0]
                 topic = ['/' + parts[1]]
-                LOGGER.info("Using provider-specific topic %s for %s"
+                LOGGER.info("Using provider-specific topic %s for %s",
                             topic, provider)
             self.listeners.append(Listener('tcp://' + provider, topic,
                                            callback, **attrs))

--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -25,7 +25,7 @@ import logging
 import logging.handlers
 import os
 from threading import Lock, Timer
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse, urlunparse
 import argparse
 
 from posttroll.message import Message
@@ -118,8 +118,10 @@ class Listeners(object):
                 topic = ['/' + parts[1]]
                 LOGGER.info("Using provider-specific topic %s for %s",
                             topic, provider)
-            self.listeners.append(Listener('tcp://' + provider, topic,
-                                           callback, **attrs))
+            self.listeners.append(Listener(
+                urlunparse(('tcp', provider, '', '', '', '')),
+                topic,
+                callback, **attrs))
 
     def start(self):
         for listener in self.listeners:

--- a/examples/move_it_client.ini
+++ b/examples/move_it_client.ini
@@ -30,3 +30,17 @@ login = user
 topic = /1b/hrit-segment/0deg
 # Port for file requests: 0 = random
 publish_port = 0
+
+# Example using provider specific topics
+[eumetcast_hrit_0deg_scp_per_server_topics]
+# Servers to listen, <server>:<port>
+# Use the port number defined with the -p flag for server or mirror
+providers = satmottag2:9010/topic/1 satmottag:9010/topic/2 explorer:9010/topic/3
+# Local destination for the data using SCP
+destination = scp:///tmp/foo
+# Login credentials for local SSH server.  Using keys, so no password given
+login = user
+# Topic to follow. Common for every provider. Optional.
+# topic = /1b/hrit-segment/0deg
+# Port for file requests: 0 = random
+publish_port = 0

--- a/examples/move_it_mirror.ini
+++ b/examples/move_it_mirror.ini
@@ -62,3 +62,24 @@ topic = /1b/hrit-segment/0deg
 # prog = /path/to/xRITDecompress
 # After decompression, delete the original compressed file
 # delete = True
+
+[eumetcast-hrit-0deg_scp_per_server_topic]
+# client part, the incoming data, providers with topics
+providers = satmottag2:9011/topic/1 satmottag:9011/topic/2
+login = user
+# Destination where the data are saved locally
+destination = scp:///tmp/bar/
+# Topics listened for advertised incoming data from all providers. Optional.
+client_topic = /1b/hrit-segment/0deg
+publish_port = 0
+
+# server part
+# Filepattern of the served files = same files coming in (after decompression)
+origin = /tmp/H-000-{series:_<6s}-{platform_name:_<12s}-{channel:_<9s}-{segment:_<9s}-{nominal_time:%Y%m%d%H%M}-{compressed:_<2s}
+# Other clients send requests to this address and port
+request_address = 193.44.81.191
+request_port = 9338
+# Additional information to add to the published message
+info = sensor=seviri
+# Advertise the data with this topic
+topic = /1b/hrit-segment/0deg

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -409,7 +409,8 @@ def reload_config(filename, chains, callback=request_push, pub_instance=None):
             for provider in chains[key]["providers"]:
                 if '/' in provider.split(':')[-1]:
                     parts = urlparse(provider)
-                    provider = parts.scheme + '://' + parts.netloc
+                    provider = urlunparse((parts.scheme, parts.netloc,
+                                           '', '', '', ''))
                     topics.append(parts.path)
                 chains[key]["listeners"][provider] = Listener(
                     provider,

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -409,8 +409,14 @@ def reload_config(filename, chains, callback=request_push, pub_instance=None):
             for provider in chains[key]["providers"]:
                 if '/' in provider.split(':')[-1]:
                     parts = urlparse(provider)
-                    provider = urlunparse((parts.scheme, parts.netloc,
-                                           '', '', '', ''))
+                    if parts.scheme != '':
+                        provider = urlunparse((parts.scheme, parts.netloc,
+                                               '', '', '', ''))
+                    else:
+                        # If there's no scheme, urlparse thinks the
+                        # URI is a local file
+                        provider = urlunparse(('tcp', parts.path,
+                                               '', '', '', ''))
                     topics.append(parts.path)
                 chains[key]["listeners"][provider] = Listener(
                     provider,

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -87,7 +87,7 @@ def read_config(filename):
             continue
         else:
             res[section]["providers"] = [
-                "tcp://" + item for item in res[section]["providers"].split()
+                "tcp://" + item.split('/', 1)[0] for item in res[section]["providers"].split()
             ]
 
         if "destination" not in res[section]:

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -407,6 +407,10 @@ def reload_config(filename, chains, callback=request_push, pub_instance=None):
             if val.get("heartbeat", False):
                 topics.append(SERVER_HEARTBEAT_TOPIC)
             for provider in chains[key]["providers"]:
+                if '/' in provider.split(':')[-1]:
+                    parts = urlparse(provider)
+                    provider = parts.scheme + '://' + parts.netloc
+                    topics.append(parts.path)
                 chains[key]["listeners"][provider] = Listener(
                     provider,
                     topics,


### PR DESCRIPTION
With this PR it is possible to provide a topic specific to each provider. If `topic` (for client) or `client_topic` (for mirror) is defined, it will be subscribed on every provider.