### PR TITLE
Fix move_it function to run with empty relative path

### DIFF
--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -263,8 +263,7 @@ def unpack_and_create_local_message(msg, local_dir, unpack=None, delete=False):
         packname = var.pop('uid')
         del var['uri']
         archive = os.path.join(local_dir, packname)
-        with open(archive, 'rb+') as arch_file:
-            os.fsync(arch_file.fileno())
+        os.fsync(arch_fd)
         new_names = unpackers[unpack](archive, delete)
 
         var['dataset'] = [dict(uid=nn, uri=os.path.join(local_dir, nn)) for nn in new_names]

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -263,7 +263,8 @@ def unpack_and_create_local_message(msg, local_dir, unpack=None, delete=False):
         packname = var.pop('uid')
         del var['uri']
         archive = os.path.join(local_dir, packname)
-        os.fsync(arch_fd)
+        with open(archive, 'rb+') as arch_file:
+            os.fsync(arch_file.fileno())
         new_names = unpackers[unpack](archive, delete)
 
         var['dataset'] = [dict(uid=nn, uri=os.path.join(local_dir, nn)) for nn in new_names]

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -262,9 +262,7 @@ def unpack_and_create_local_message(msg, local_dir, unpack=None, delete=False):
             return var
         packname = var.pop('uid')
         del var['uri']
-        archive = os.path.join(local_dir, packname)
-        os.fsync(arch_fd)
-        new_names = unpackers[unpack](archive, delete)
+        new_names = unpackers[unpack](os.path.join(local_dir, packname), delete)
 
         var['dataset'] = [dict(uid=nn, uri=os.path.join(local_dir, nn)) for nn in new_names]
         return var

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -262,7 +262,9 @@ def unpack_and_create_local_message(msg, local_dir, unpack=None, delete=False):
             return var
         packname = var.pop('uid')
         del var['uri']
-        new_names = unpackers[unpack](os.path.join(local_dir, packname), delete)
+        archive = os.path.join(local_dir, packname)
+        os.fsync(arch_fd)
+        new_names = unpackers[unpack](archive, delete)
 
         var['dataset'] = [dict(uid=nn, uri=os.path.join(local_dir, nn)) for nn in new_names]
         return var

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -162,7 +162,7 @@ class RequestManager(Thread):
         """
         for the_dict in gen_dict_contains(message.data, 'uri'):
             uri = urlparse(the_dict['uri'])
-            rel_path = the_dict.get('path', '')
+            rel_path = the_dict.get('path', None)
             pathname = uri.path
             # FIXME: check against file_cache
             if 'origin' in self._attrs and not fnmatch.fnmatch(
@@ -645,12 +645,20 @@ def unpack(pathname,
 # Mover
 
 
-def move_it(pathname, destination, attrs=None, hook=None, rel_path=''):
-    """Check if the file pointed by *filename* is in the filelist, and move it
+def move_it(pathname, destination, attrs=None, hook=None, rel_path=None):
+    """Check if the file pointed by *pathname* is in the filelist, and move it
     if it is.
+
+    The *destination* provided is used, and if *rel_path* is provided, it will
+    be appended to the destination path.
+
     """
     dest_url = urlparse(destination)
-    new_dest = dest_url._replace(path=os.path.join(dest_url.path, rel_path))
+    if rel_path is not None:
+        new_path = os.path.join(dest_url.path, rel_path)
+    else:
+        new_path = dest_url.path
+    new_dest = dest_url._replace(path=new_path)
     fake_dest = clean_url(new_dest)
 
     LOGGER.debug("Copying to: %s", fake_dest)


### PR DESCRIPTION
The relative path option was added to move_it but defaulted to `""` which turns the provided destination to a directory. This PR fixes this.