### PR TITLE
Expose ListenerContainer config items

### DIFF
--- a/examples/dispatch.yaml
+++ b/examples/dispatch.yaml
@@ -4,6 +4,12 @@ target1:
     connection_uptime: 60
   filepattern: '{platform_name}_{start_time}.{format}'
   directory: /input_data/{sensor}
+  subscribe_addresses:
+    - tcp://127.0.0.1:40000
+  nameserver: 127.0.0.1
+  subscribe_services:
+    - service_name_1
+    - service_name_2
   aliases:
     product:
       natural_color: dnc

--- a/examples/dispatch.yaml
+++ b/examples/dispatch.yaml
@@ -4,12 +4,15 @@ target1:
     connection_uptime: 60
   filepattern: '{platform_name}_{start_time}.{format}'
   directory: /input_data/{sensor}
-  subscribe_addresses:
-    - tcp://127.0.0.1:40000
-  nameserver: 127.0.0.1
-  subscribe_services:
-    - service_name_1
-    - service_name_2
+  # Optional direct subscriptions
+  # subscribe_addresses:
+  #   - tcp://127.0.0.1:40000
+  # Nameserver to connect to. Optional. Defaults to localhost
+  # nameserver: 127.0.0.1
+  # Subscribe to specific services. Optional. Default: connect to all services
+  # subscribe_services:
+  #   - service_name_1
+  #   - service_name_2
   aliases:
     product:
       natural_color: dnc

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -39,12 +39,15 @@ Example config::
         connection_uptime: 60
       filepattern: '{platform_name}_{start_time}.{format}'
       directory: /input_data/{sensor}
-      subscribe_addresses:
-        - tcp://127.0.0.1:40000
-      nameserver: 127.0.0.1
-      subscribe_services:
-        - service_name_1
-        - service_name_2
+      # Optional direct subscriptions
+      # subscribe_addresses:
+      #   - tcp://127.0.0.1:40000
+      # Nameserver to connect to. Optional. Defaults to localhost
+      # nameserver: 127.0.0.1
+      # Subscribe to specific services. Optional. Default: connect to all services
+      # subscribe_services:
+      #   - service_name_1
+      #   - service_name_2
       aliases:
         product:
           natural_color: dnc

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -39,6 +39,12 @@ Example config::
         connection_uptime: 60
       filepattern: '{platform_name}_{start_time}.{format}'
       directory: /input_data/{sensor}
+      subscribe_addresses:
+        - tcp://127.0.0.1:40000
+      nameserver: 127.0.0.1
+      subscribe_services:
+        - service_name_1
+        - service_name_2
       aliases:
         product:
           natural_color: dnc
@@ -81,6 +87,9 @@ Each host section have to contain the following information:
       pass to the moving function. See the `trollmoves.movers` module documentation.
     - `aliases` (optional): A dictionary of metadata items to change for the
       final filename. These are not taken into account for checking the conditions.
+    - `nameserver` (optional): Address of a nameserver to connect to.  Default: 'localhost'.
+    - `addresses` (optional): List of TCP connections to listen for messages.
+    - `services` (optional): List of service names to subscribe to.  Default: connect to all services.
 
 Note that the `host`, `filepattern`, and `directory` items can be overridden in
 the dispatch_configs section.
@@ -259,7 +268,13 @@ class Dispatcher(Thread):
                     # FIXME: make sure to get the last messages though
                     self.listener.stop()
                 self.config = new_config
-                self.listener = ListenerContainer(topics)
+                addresses = client_config.get('subscribe_addresses', None)
+                nameserver = client_config.get('nameserver', 'localhost')
+                services = client_config.get('subscribe_services', '')
+                self.listener = ListenerContainer(topics=topics,
+                                                  addresses=addresses,
+                                                  nameserver=nameserver,
+                                                  services=services)
                 self.topics = topics
 
         except KeyError as err:

--- a/trollmoves/tests/test_dispatcher.py
+++ b/trollmoves/tests/test_dispatcher.py
@@ -290,6 +290,13 @@ target3:
   host: ""
   filepattern: '{platform_name}_{start_time:%Y%m%d%H%M}.{format}'
   directory: """ + os.path.join(gettempdir(), 'dptest') + """
+  subscribe_addresses:
+    - tcp://127.0.0.1:40000
+  nameserver: 127.0.0.1
+  subscribe_services:
+    - service_name_1
+    - service_name_2
+
   dispatch_configs:
     - topics:
         - /level2/viirs
@@ -345,6 +352,12 @@ def test_dispatcher():
                     queue.put(msg)
                     time.sleep(.1)
                     assert os.path.exists(expected_file)
+            # Check that the listener config items are passed correctly
+            lc.assert_called_once_with(
+                addresses=['tcp://127.0.0.1:40000'],
+                nameserver='127.0.0.1',
+                services=['service_name_1', 'service_name_2'],
+                topics={'/level3/cloudtype', '/level2/viirs', '/level2/avhrr'})
     finally:
         if dp is not None:
             dp.close()


### PR DESCRIPTION
This PR exposes config ListenerContainer config items  `nameserver`, `addresses` and `services`.