### PR TITLE
Fix deletion of compressed files on the client

### DIFF
--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -144,12 +144,23 @@ def test_unpack_and_create_local_message(unpackers):
     # One file with 'xrit' compression
     kwargs['compression'] = 'xrit'
     unpackers['xrit'].return_value = 'new_file1.png'
-    res = unp(copy.copy(MSG_FILE_XRIT), local_dir, **kwargs)
+    with patch('os.remove') as remove:
+        res = unp(copy.copy(MSG_FILE_XRIT), local_dir, **kwargs)
+    # Delete has not been setup, so it shouldn't been done
+    remove.assert_not_called()
     assert res.data['uri'] == os.path.join(local_dir, 'new_file1.png')
     assert res.data['uid'] == 'new_file1.png'
     assert res.subject == MSG_FILE_XRIT.subject
     assert res.type == MSG_FILE_XRIT.type
     unpackers['xrit'].assert_called_with('/local/file1-C_', **kwargs)
+
+    # One file with 'xrit' compression, delete the compressed file
+    kwargs['delete'] = True
+    unpackers['xrit'].return_value = 'new_file1.png'
+    with patch('os.remove') as remove:
+        res = unp(copy.copy(MSG_FILE_XRIT), local_dir, **kwargs)
+    assert remove.called_once_with('/local/file1-C_')
+    del kwargs['delete']
 
     # Multiple files returned when decompression is applied. 'tar'
     # compression, 'file' message

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -105,16 +105,17 @@ def translate_dict_item(var, key, callback):
         return var
 
 
-def translate_dict(var, keys, callback):
+def translate_dict(var, keys, callback, **kwargs):
     newvar = var.copy()
     if hasattr(var, 'items'):
         if set(var.keys()) & set(keys):
-            newvar = callback(var)
+            newvar = callback(var, **kwargs)
         for k, v in newvar.items():
             if hasattr(v, 'items'):
-                newvar[k] = translate_dict(v, keys, callback)
+                newvar[k] = translate_dict(v, keys, callback, **kwargs)
             elif isinstance(v, list):
-                newvar[k] = [translate_dict(d, keys, callback) for d in v]
+                newvar[k] = [translate_dict(d, keys, callback, **kwargs)
+                             for d in v]
         return newvar
     else:
         return var


### PR DESCRIPTION
This PR fixes the deletion of transferred compressed files when `delete = True` has been configured.