### PR TITLE
Fix unpack_tar() to return a tuple or string

### DIFF
--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -239,7 +239,11 @@ def unpack_tar(filename, **kwargs):
             members = tar.getmembers()
     except tarfile.ReadError as err:
         raise IOError(str(err))
-    return (member.name for member in members)
+    fnames = tuple(os.path.join(destdir, member.name) for member in members)
+    if len(fnames) == 1:
+        return fnames[0]
+    else:
+        return fnames
 
 
 def unpack_xrit(filename, **kwargs):

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -367,10 +367,11 @@ def unpack_and_create_local_message(msg, local_dir, **kwargs):
             LOGGER.debug("Deleting %s", os.path.join(local_dir, packname))
             os.remove(os.path.join(local_dir, packname))
         if isinstance(new_names, tuple):
-            var['dataset'] = [dict(uid=nn, uri=os.path.join(local_dir, nn))
+            var['dataset'] = [dict(uid=os.path.basename(nn),
+                                   uri=os.path.join(local_dir, nn))
                               for nn in new_names]
         else:
-            var['uid'] = new_names
+            var['uid'] = os.path.basename(new_names)
             var['uri'] = os.path.join(local_dir, new_names)
         return var
 

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -146,6 +146,52 @@ def test_unpack_bzip():
         os.remove(fname_bz2)
 
 
+def test_unpack_tar():
+    """Test unpacking of bzip2 files."""
+    from trollmoves.client import unpack_tar
+    from tempfile import gettempdir
+    import tarfile
+
+    try:
+        # Write two test files
+        test_txt_file_1 = os.path.join(gettempdir(), "unpack_test_1.txt")
+        with open(test_txt_file_1, 'w') as fid:
+            fid.write('test 1\n')
+        test_txt_file_2 = os.path.join(gettempdir(), "unpack_test_2.txt")
+        with open(test_txt_file_2, 'w') as fid:
+            fid.write('test 2\n')
+        # Write a test .tar file with single file
+        test_tar_file = os.path.join(gettempdir(), "unpack_test.tar")
+        with tarfile.open(test_tar_file, 'w') as fid:
+            fid.add(test_txt_file_1, arcname=os.path.basename(test_txt_file_1))
+        os.remove(test_txt_file_1)
+
+        new_files = unpack_tar(test_tar_file)
+        assert new_files == test_txt_file_1
+        assert os.path.exists(test_txt_file_1)
+        os.remove(test_txt_file_1)
+
+        # Add another file to the .tar
+        with tarfile.open(test_tar_file, 'a') as fid:
+            fid.add(test_txt_file_2, arcname=os.path.basename(test_txt_file_2))
+        os.remove(test_txt_file_2)
+
+        new_files = unpack_tar(test_tar_file)
+        assert isinstance(new_files, tuple)
+        assert test_txt_file_1 in new_files
+        assert test_txt_file_2 in new_files
+        assert os.path.exists(test_txt_file_1)
+        assert os.path.exists(test_txt_file_2)
+
+    finally:
+        if os.path.exists(test_txt_file_1):
+            os.remove(test_txt_file_1)
+        if os.path.exists(test_txt_file_2):
+            os.remove(test_txt_file_2)
+        if os.path.exists(test_tar_file):
+            os.remove(test_tar_file)
+
+
 @patch('trollmoves.client.unpackers')
 def test_unpack_and_create_local_message(unpackers):
     """Test unpacking and updating the message with new filenames."""

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -219,6 +219,12 @@ def test_unpack_and_create_local_message(unpackers):
     assert res.type == MSG_FILE_TAR.type
     unpackers['tar'].assert_called_with('/local/file1.tar', **kwargs)
 
+    # The unpacker returns a full path for some reason
+    unpackers['tar'].return_value = os.path.join(local_dir, 'new_file1.png')
+    res = unp(copy.copy(MSG_FILE_TAR), local_dir, **kwargs)
+    assert res.data['uri'] == os.path.join(local_dir, 'new_file1.png')
+    assert res.data['uid'] == 'new_file1.png'
+
     # One file with 'bz2' compression
     kwargs['compression'] = 'bzip'
     unpackers['bzip'].return_value = 'file1.png'


### PR DESCRIPTION
This PR fixes `unpack_tar()` so that it either returns a tuple of filenames or a single filename.