### PR TITLE
Fix dispatcher transfers for scp protocol

### DIFF
--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -156,6 +156,8 @@ import yaml
 
 import inotify.adapters
 from inotify.constants import IN_MODIFY, IN_CLOSE_WRITE, IN_CREATE, IN_MOVED_TO
+from six.moves.urllib.parse import urlsplit, urlunsplit
+
 from posttroll.listener import ListenerContainer
 from trollmoves.movers import move_it
 from trollmoves.utils import clean_url
@@ -331,7 +333,10 @@ class Dispatcher(Thread):
             if key in mda:
                 mda[key] = aliases.get(mda[key], mda[key])
         path = compose(path, mda)
-        return host + path, connection_parameters
+        parts = urlsplit(host)
+        host_path = urlunsplit((parts.scheme, parts.netloc, path,
+                                parts.query, parts.fragment))
+        return host_path, connection_parameters
 
     def close(self):
         """Shutdown the dispatcher."""

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -155,12 +155,15 @@ from threading import Thread
 import yaml
 
 import inotify.adapters
+from inotify.constants import IN_MODIFY, IN_CLOSE_WRITE, IN_CREATE, IN_MOVED_TO
 from posttroll.listener import ListenerContainer
 from trollmoves.movers import move_it
 from trollmoves.utils import clean_url
 from trollsift import compose
 
 logger = logging.getLogger(__name__)
+
+INOTIFY_MASK = IN_MODIFY | IN_CLOSE_WRITE | IN_CREATE | IN_MOVED_TO
 
 
 class Notifier(Thread):
@@ -171,7 +174,7 @@ class Notifier(Thread):
         self.filename = filename
         self.loop = True
         self.i = inotify.adapters.Inotify()
-        self.i.add_watch(filename)
+        self.i.add_watch(filename, mask=INOTIFY_MASK)
         self.event_types = set(event_types)
         self.callback = callback
         super().__init__()

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -302,10 +302,9 @@ class Dispatcher(Thread):
         destinations = []
         for client, config in self.config.items():
             for item in config['dispatch_configs']:
-                # remove 'pytroll:/'
                 for topic in item['topics']:
-                    msg.subject[9:].startswith(topic)
-                    break
+                    if msg.subject.startswith(topic):
+                        break
                 else:
                     continue
                 if check_conditions(msg, item):

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -153,7 +153,6 @@ from queue import Empty
 from threading import Thread
 
 import yaml
-from six.moves.urllib.parse import urljoin
 
 import inotify.adapters
 from posttroll.listener import ListenerContainer
@@ -329,7 +328,7 @@ class Dispatcher(Thread):
             if key in mda:
                 mda[key] = aliases.get(mda[key], mda[key])
         path = compose(path, mda)
-        return urljoin(host, path), connection_parameters
+        return host + path, connection_parameters
 
     def close(self):
         """Shutdown the dispatcher."""

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -59,7 +59,8 @@ class MoveItBase(object):
         else:
             # Also Mirror uses the reload_config from the Server
             from trollmoves.server import reload_config
-            reload_config(filename, self.chains, *args, publisher=self.pub)
+            reload_config(filename, self.chains, *args, publisher=self.pub,
+                          **kwargs)
 
     def signal_reload_cfg_file(self, *args):
         del args

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -36,6 +36,7 @@ from trollmoves.server import EventHandler
 LOGGER = logging.getLogger("move_it_base")
 LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
 
+
 class MoveItBase(object):
 
     def __init__(self, cmd_args, chain_type):

--- a/trollmoves/tests/test_dispatcher.py
+++ b/trollmoves/tests/test_dispatcher.py
@@ -384,7 +384,7 @@ def test_create_dest_url():
             msg.subject = '/level2/viirs'
             msg.data = {'sensor': 'viirs', 'product': 'green_snow', 'platform_name': 'NOAA-20',
                         'start_time': datetime(2019, 9, 19, 9, 19), 'format': 'tif'}
-            url, params= dp.create_dest_url(msg, 'target2', config['target2'])
+            url, params = dp.create_dest_url(msg, 'target2', config['target2'])
         expected_url = "ssh://server.target2.com/satellite/viirs/sat_201909190919_NOAA-20.tif"
         assert url == expected_url
         assert params == {'ssh_key_filename': '~/.ssh/rsa_id.pub'}

--- a/trollmoves/tests/test_dispatcher.py
+++ b/trollmoves/tests/test_dispatcher.py
@@ -206,7 +206,7 @@ def test_get_destinations():
             dp = Dispatcher(fname)
             dp.config = yaml.safe_load(test_yaml1)
             msg = Mock()
-            msg.subject = 'pytroll://level2/viirs'
+            msg.subject = '/level2/viirs'
             msg.data = {'sensor': 'viirs', 'product': 'green_snow', 'platform_name': 'NOAA-20',
                         'start_time': datetime(2019, 9, 19, 9, 19), 'format': 'tif'}
             expected_url = 'ftp://ftp.target1.com/input_data/viirs/NOAA-20_201909190919.tif'
@@ -268,7 +268,7 @@ def test_get_destinations_with_aliases():
             dp = Dispatcher(fname)
             dp.config = yaml.safe_load(test_yaml_aliases)
             msg = Mock()
-            msg.subject = 'pytroll://level2/viirs'
+            msg.subject = '/level2/viirs'
             msg.data = {'sensor': 'viirs', 'product': 'green_snow', 'platform_name': 'NOAA-20',
                         'start_time': datetime(2019, 9, 19, 9, 19), 'format': 'tif'}
             expected_url = 'ftp://ftp.target1.com/input_data/viirs/NOAA-20_gs_201909190919.tif'
@@ -343,7 +343,7 @@ def test_dispatcher():
                 with NamedTemporaryFile('w') as test_file:
                     msg = Mock()
                     msg.type = 'file'
-                    msg.subject = 'pytroll://level2/viirs'
+                    msg.subject = '/level2/viirs'
                     msg.data = {'sensor': 'viirs', 'product': 'green_snow', 'platform_name': 'NOAA-20',
                                 'start_time': datetime(2019, 9, 19, 9, 19), 'format': 'tif',
                                 'area': 'euron1',


### PR DESCRIPTION
This PR fixes a bug that caused all SCP transfers with `dispatcher.py` to be straight file copies.

Also fixes `--disable-backlog` use in `move_it_server`.