### PR TITLE
Reload only the actual config file when it is modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## Version v0.4.0 (2020/02/10)
+
+### Issues Closed
+
+* [Issue 56](https://github.com/pytroll/trollmoves/issues/56) - All `push`, `ack` and `file` messages are published
+
+In this release 1 issue was closed.
+
+### Pull Requests Merged
+
+#### Bugs fixed
+
+* [PR 55](https://github.com/pytroll/trollmoves/pull/55) - Fix dispatcher transfers for scp protocol
+* [PR 53](https://github.com/pytroll/trollmoves/pull/53) - Fix unpack_tar() to return a tuple or string
+* [PR 51](https://github.com/pytroll/trollmoves/pull/51) - Fix deletion of compressed files on the client
+* [PR 50](https://github.com/pytroll/trollmoves/pull/50) - Hotfix client decompression when decompression not defined
+
+#### Features added
+
+* [PR 52](https://github.com/pytroll/trollmoves/pull/52) - Add bzip decompression to client
+* [PR 49](https://github.com/pytroll/trollmoves/pull/49) - Add more decompression methods to client
+* [PR 46](https://github.com/pytroll/trollmoves/pull/46) - Add config option for ssh port. Defaults to 22
+* [PR 44](https://github.com/pytroll/trollmoves/pull/44) - Expose ListenerContainer config items
+* [PR 43](https://github.com/pytroll/trollmoves/pull/43) - Fix yaml loading and hooks usage for dispatcher
+* [PR 42](https://github.com/pytroll/trollmoves/pull/42) - Hot-spare client(s)
+* [PR 41](https://github.com/pytroll/trollmoves/pull/41) - Accept log configs in dispatcher
+
+In this release 11 pull requests were closed.
+
 ## Version 0.3.0 (2019/09/25)
 
 ### Issues Closed

--- a/bin/move_it.py
+++ b/bin/move_it.py
@@ -507,7 +507,12 @@ class EventHandler(pyinotify.ProcessEvent):
         self._fun = fun
 
     def process_IN_CLOSE_WRITE(self, event):
-        """On closing after writing.
+        """On closing a writable file.
+        """
+        self._fun(event.pathname)
+
+    def process_IN_MODIFY(self, event):
+        """The file was modified.
         """
         self._fun(event.pathname)
 

--- a/bin/move_it.py
+++ b/bin/move_it.py
@@ -210,6 +210,7 @@ def reload_config(filename, disable_backlog=False):
 
     old_glob = []
 
+    config_changed = False
     for key, val in new_chains.items():
         identical = True
         if key in chains:
@@ -218,6 +219,7 @@ def reload_config(filename, disable_backlog=False):
                     ((key2 not in chains[key]) or
                      (chains[key][key2] != val2))):
                     identical = False
+                    config_changed = True
                     break
             if identical:
                 continue
@@ -297,7 +299,9 @@ def reload_config(filename, disable_backlog=False):
         del chains[key]
         LOGGER.debug("Removed %s", key)
 
-    LOGGER.debug("Reloaded config from %s", filename)
+    if config_changed:
+        LOGGER.debug("Reloaded config from %s", filename)
+
     if old_glob and not disable_backlog:
         fnames = []
         for pattern in old_glob:
@@ -310,7 +314,8 @@ def reload_config(filename, disable_backlog=False):
                     fp_ = open(fname, "ab")
                     fp_.close()
         old_glob = []
-    LOGGER.debug("done reloading config")
+        LOGGER.info("Old files transferred")
+
 # Unpackers
 
 # xrit

--- a/bin/move_it.py
+++ b/bin/move_it.py
@@ -658,7 +658,7 @@ def main():
 
     LOGGER.info("Starting up.")
 
-    mask = (pyinotify.IN_MODIFY |
+    mask = (pyinotify.IN_CLOSE_WRITE |
             pyinotify.IN_MOVED_TO |
             pyinotify.IN_CREATE)
     watchman = pyinotify.WatchManager()

--- a/bin/move_it.py
+++ b/bin/move_it.py
@@ -201,7 +201,7 @@ def read_config(filename):
     return res
 
 
-def reload_config(filename):
+def reload_config(filename, disable_backlog=False):
     """Rebuild chains if needed (if the configuration changed) from *filename*.
     """
     LOGGER.debug("New config file detected! %s", filename)
@@ -298,7 +298,7 @@ def reload_config(filename):
         LOGGER.debug("Removed %s", key)
 
     LOGGER.debug("Reloaded config from %s", filename)
-    if old_glob:
+    if old_glob and not disable_backlog:
         fnames = []
         for pattern in old_glob:
             fnames += glob.glob(pattern)
@@ -619,6 +619,9 @@ def parse_args():
                         help="The configuration file to run on.")
     parser.add_argument("-l", "--log",
                         help="The file to log to. stdout otherwise.")
+    parser.add_argument("-d", "--disable-backlog", default=False,
+                        action="store_true",
+                        help="Disable handling of backlog. Default: resend exising files.")
     return parser.parse_args()
 
 
@@ -665,7 +668,8 @@ def main():
     signal.signal(signal.SIGTERM, chains_stop)
 
     try:
-        reload_config(cmd_args.config_file)
+        reload_config(cmd_args.config_file,
+                      disable_backlog=cmd_args.disable_backlog)
         notifier.loop()
     except KeyboardInterrupt:
         LOGGER.debug("Interrupting")

--- a/bin/move_it.py
+++ b/bin/move_it.py
@@ -645,13 +645,13 @@ def main():
 
     LOGGER.info("Starting up.")
 
-    mask = (pyinotify.IN_CLOSE_WRITE |
+    mask = (pyinotify.IN_MODIFY |
             pyinotify.IN_MOVED_TO |
             pyinotify.IN_CREATE)
     watchman = pyinotify.WatchManager()
 
     notifier = pyinotify.Notifier(watchman, EventHandler(reload_config))
-    watchman.add_watch(os.path.dirname(cmd_args.config_file), mask)
+    watchman.add_watch(cmd_args.config_file, mask)
 
     def chains_stop(*args):
         del args

--- a/bin/move_it.py
+++ b/bin/move_it.py
@@ -516,11 +516,6 @@ class EventHandler(pyinotify.ProcessEvent):
         """
         self._fun(event.pathname)
 
-    def process_IN_MODIFY(self, event):
-        """The file was modified.
-        """
-        self._fun(event.pathname)
-
     def process_IN_CREATE(self, event):
         """On closing after linking.
         """


### PR DESCRIPTION
The current behaviour of `move_it.py` causes the script to act on _all_ the changes in the directory where the configuration file is located. That is, if any of the other files in the directory were opened and closed those files were tried to be read as a valid configuration file.

This PR fixes this so that only the _modification_ of the actual configuration file triggers the reload.

The reload by default also triggers resending of all existing files. To prevent this (and transfering possibly a file that is being actively written to) a command line argument `-d` or `--disable-backlog` is added to disable it.