### PR TITLE
Fix rpm names for newer distros

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bdist_rpm]
 provides=trollmoves
-requires=posttroll python-inotify trollsift python-netifaces python-zmq
+requires=posttroll python3-inotify trollsift python3-netifaces pyzmq
 no-autoreq=True
 release=1
 


### PR DESCRIPTION
This fixes trollmoves to require the right packages with rhel8 among others.