### PR TITLE
Fix iterate_messages() generator raising StopIteration

### DIFF
--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -471,7 +471,7 @@ def iterate_messages(uid):
         try:
             msg = get_next_msg(uid)
         except IndexError:
-            raise StopIteration
+            return
         yield msg
 
 

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -83,9 +83,9 @@ def test_unpack_xrit(check_output, remove):
     try:
         res = unpack_xrit(fname_in, **kwargs)
         # Should raise OSError as xritdecompressor hasn't been defined
-        assert False
+        raise AssertionError
     except OSError:
-        assert True
+        pass
     remove.assert_not_called()
 
     # Define xritdecompressor path

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -695,3 +695,14 @@ def test_add_timer(CTimer, hot_spare_timer_lock):
     hot_spare_timer_lock.__enter__.assert_called_once()
     assert UID_FILE1 in ongoing_hot_spare_timers
     assert len(ongoing_hot_spare_timers) == 1
+
+
+@patch('trollmoves.client.ongoing_transfers_lock')
+def test_iterate_messages(lock):
+    """Test iterate_messages()."""
+    from trollmoves.client import ongoing_transfers, iterate_messages
+    values = ["bar", "baz"]
+    ongoing_transfers["foo"] = values.copy()
+    res = iterate_messages("foo")
+    assert list(res) == values
+    assert len(lock.__enter__.mock_calls) == 3


### PR DESCRIPTION
This PR fixes `iterate_messages()` what was raising `StopIteration` when it should just return.

Also adds an unit test for this function, and fixes a flake8 complaint about invalid usage of `assert`:

`trollmoves/tests/test_client.py:86:9: B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().`