### PR TITLE
Create new compose-tags with aliases

### DIFF
--- a/examples/dispatch.yaml
+++ b/examples/dispatch.yaml
@@ -21,6 +21,13 @@ target1:
     product:
       natural_color: dnc
       overview: ovw
+  # Alternate way in using aliases.  This will create a new tag named
+  #   "product_dir", but will also retain the original tag "product"
+  # aliases:
+  #   product:
+  #   - _alias_name: product_dir
+  #     green_snow: alternate_dir_for_green_snow
+  #   - green_snow: gs
   dispatch_configs:
     - topics:
         - /level2/viirs

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -374,9 +374,16 @@ class Dispatcher(Thread):
         host = info_dict['host']
         path = os.path.join(info_dict['directory'], info_dict['filepattern'])
         mda = msg.data.copy()
+
         for key, aliases in defaults.get('aliases', {}).items():
-            if key in mda:
-                mda[key] = aliases.get(mda[key], mda[key])
+            if isinstance(aliases, dict):
+                aliases = [aliases]
+
+            for alias in aliases:
+                new_key = alias.pop("_alias_name", key)
+                if key in msg.data:
+                    mda[new_key] = alias.get(msg.data[key], msg.data[key])
+
         path = compose(path, mda)
         parts = urlsplit(host)
         host_path = urlunsplit((parts.scheme, parts.netloc, path,

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -348,27 +348,29 @@ class Dispatcher(Thread):
         """Get the destinations for this message."""
         destinations = []
         for client, config in self.config.items():
-            for item in config['dispatch_configs']:
-                for topic in item['topics']:
+            for disp_config in config['dispatch_configs']:
+                for topic in disp_config['topics']:
                     if msg.subject.startswith(topic):
                         break
                 else:
                     continue
-                if check_conditions(msg, item):
-                    destinations.append(self.create_dest_url(msg, client, item))
+                if check_conditions(msg, disp_config):
+                    destinations.append(
+                        self.create_dest_url(msg, client, disp_config))
         return destinations
 
-    def create_dest_url(self, msg, client, item):
+    def create_dest_url(self, msg, client, disp_config):
         """Create the destination URL and the connection parameters."""
         defaults = self.config[client]
         info_dict = dict()
         for key in ['host', 'directory', 'filepattern']:
             try:
-                info_dict[key] = item[key]
+                info_dict[key] = disp_config[key]
             except KeyError:
                 info_dict[key] = defaults[key]
-        connection_parameters = item.get('connection_parameters',
-                                         defaults.get('connection_parameters'))
+        connection_parameters = disp_config.get(
+            'connection_parameters',
+            defaults.get('connection_parameters'))
         host = info_dict['host']
         path = os.path.join(info_dict['directory'], info_dict['filepattern'])
         mda = msg.data.copy()

--- a/trollmoves/tests/test_dispatcher.py
+++ b/trollmoves/tests/test_dispatcher.py
@@ -237,7 +237,7 @@ def test_get_destinations():
             assert len(res) == 2
 
 
-test_yaml_aliases = """
+test_yaml_aliases_simple = """
 target1:
   host: ftp://ftp.target1.com
   connection_parameters:
@@ -254,6 +254,25 @@ target1:
         - /level2/viirs
 """
 
+test_yaml_aliases_multiple = """
+target1:
+  host: ftp://ftp.target1.com
+  connection_parameters:
+    connection_uptime: 20
+  filepattern: '{platform_name}_{product}_{start_time:%Y%m%d%H%M}.{format}'
+  directory: /input_data/{product_dir}
+  aliases:
+    product:
+      - _alias_name: product_dir
+        green_snow: alternate_dir_for_green_snow
+      - green_snow: gs
+    variant:
+      DR: direct_readout
+  dispatch_configs:
+    - topics:
+        - /level2/viirs
+"""
+
 
 def test_get_destinations_with_aliases():
     """Check getting destination urls."""
@@ -261,7 +280,7 @@ def test_get_destinations_with_aliases():
         with NamedTemporaryFile('w') as the_file:
             fname = the_file.name
             dp = Dispatcher(fname)
-            dp.config = yaml.safe_load(test_yaml_aliases)
+            dp.config = yaml.safe_load(test_yaml_aliases_simple)
             msg = Mock()
             msg.subject = '/level2/viirs'
             msg.data = {'sensor': 'viirs', 'product': 'green_snow', 'platform_name': 'NOAA-20',
@@ -271,6 +290,14 @@ def test_get_destinations_with_aliases():
 
             res = dp.get_destinations(msg)
             assert len(res) == 1
+            url, attrs, client = res[0]
+            assert url == expected_url
+            assert attrs == expected_attrs
+            assert client == "target1"
+
+            dp.config = yaml.safe_load(test_yaml_aliases_multiple)
+            res = dp.get_destinations(msg)
+            expected_url = 'ftp://ftp.target1.com/input_data/alternate_dir_for_green_snow/NOAA-20_gs_201909190919.tif'
             url, attrs, client = res[0]
             assert url == expected_url
             assert attrs == expected_attrs

--- a/trollmoves/tests/test_dispatcher.py
+++ b/trollmoves/tests/test_dispatcher.py
@@ -252,24 +252,6 @@ target1:
   dispatch_configs:
     - topics:
         - /level2/viirs
-        - /level2/avhrr
-      conditions:
-        # key matches metadata items or provides default
-        - product: [green_snow, true_color]
-          sensor: viirs
-        - product: [green_snow, overview]
-          sensor: avhrr
-          # special section "except" for negating
-          except:
-            platform_name: NOAA-15
-    - topics:
-        - /level3/cloudtype
-      directory: /input/cloud_products
-      conditions:
-        - area: omerc_bb
-          # ' 122'.strip().isdigit() -> True
-          daylight: '<30'
-          coverage: '>50'
 """
 
 


### PR DESCRIPTION
This PR adds a way to create new compose-tags with the aliases. The old format for `aliases` still works the same.

Example use case:
- target directory depends on the value of `product` in the input metadata
- the `product` in the filename pattern needs to be kept as it is originally

Solution:
```yaml
  filepattern: '{platform_name}_{product}_{start_time:%Y%m%d%H%M}.{format}'
  directory: /input_data/{product_dir}
  aliases:
    product:
      - _alias_name: product_dir
        green_snow: target_dir_for_green_snow
      - green_snow: gs
```
This will dispatch the file to `/input_data/target_dir_for_green_snow/NOAA-20_gs_20200402_1245.tif`on the target server.