### PR TITLE
Accept uri's with a full scheme (ssh, ftp,...)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bdist_rpm]
 provides=trollmoves
-requires=posttroll python3-inotify trollsift python3-netifaces pyzmq watchdog
+requires=posttroll python3-inotify trollsift python3-netifaces pyzmq python3-watchdog
 no-autoreq=True
 release=1
 

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2019
+# Copyright (c) 2012-2020
 #
 # Author(s):
 #
@@ -160,7 +160,8 @@ import yaml
 
 import inotify.adapters
 from inotify.constants import IN_MODIFY, IN_CLOSE_WRITE, IN_CREATE, IN_MOVED_TO
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from six.moves.urllib.parse import urlsplit, urlunsplit, urlparse
+import socket
 
 from posttroll.listener import ListenerContainer
 from posttroll.publisher import NoisyPublisher
@@ -268,6 +269,8 @@ class Dispatcher(Thread):
         self.topics = None
         self.listener = None
         self.publisher = None
+        self.host = socket.gethostname()
+
         if publish_port is not None:
             self.publisher = NoisyPublisher(
                 "dispatcher", port=publish_port,
@@ -318,7 +321,19 @@ class Dispatcher(Thread):
                     continue
                 destinations = self.get_destinations(msg)
                 if destinations:
-                    success = dispatch(msg.data['uri'], destinations)
+                    # Check if the url are on another host:
+                    url = urlparse(msg.data['uri'])
+                    if url.scheme != '':
+                        netloc = url.netloc
+                        if netloc != self.host:
+                            # This warning may appear even if the file path
+                            # does exist on both servers (a central file server
+                            # reachable from both). But in those cases one
+                            # should probably not use an url scheme but just a
+                            # file path:
+                            logger.warning(
+                                "uri is pointing to a file path on another server! Host=<%s> uri netloc=<%s>", self.host, netloc)
+                    success = dispatch(url.path, destinations)
                     if self.publisher:
                         self._publish(msg, destinations, success)
 

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -162,12 +162,11 @@ import inotify.adapters
 from inotify.constants import IN_MODIFY, IN_CLOSE_WRITE, IN_CREATE, IN_MOVED_TO
 from six.moves.urllib.parse import urlsplit, urlunsplit, urlparse
 import socket
-from utils import is_file_local
 from posttroll.listener import ListenerContainer
 from posttroll.publisher import NoisyPublisher
 from posttroll.message import Message
 from trollmoves.movers import move_it
-from trollmoves.utils import clean_url
+from trollmoves.utils import (clean_url, is_file_local)
 from trollsift import compose
 
 logger = logging.getLogger(__name__)

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -162,7 +162,7 @@ import inotify.adapters
 from inotify.constants import IN_MODIFY, IN_CLOSE_WRITE, IN_CREATE, IN_MOVED_TO
 from six.moves.urllib.parse import urlsplit, urlunsplit, urlparse
 import socket
-
+from utils import is_file_local
 from posttroll.listener import ListenerContainer
 from posttroll.publisher import NoisyPublisher
 from posttroll.message import Message
@@ -323,16 +323,14 @@ class Dispatcher(Thread):
                 if destinations:
                     # Check if the url are on another host:
                     url = urlparse(msg.data['uri'])
-                    if url.scheme != '':
-                        netloc = url.netloc
-                        if netloc != self.host:
-                            # This warning may appear even if the file path
-                            # does exist on both servers (a central file server
-                            # reachable from both). But in those cases one
-                            # should probably not use an url scheme but just a
-                            # file path:
-                            logger.warning(
-                                "uri is pointing to a file path on another server! Host=<%s> uri netloc=<%s>", self.host, netloc)
+                    if not is_file_local(url):
+                        # This warning may appear even if the file path
+                        # does exist on both servers (a central file server
+                        # reachable from both). But in those cases one
+                        # should probably not use an url scheme but just a
+                        # file path:
+                        raise NotImplementedError(("uri is pointing to a file path on another server! " +
+                                                   "Host=<%s> uri netloc=<%s>", self.host, url.netloc))
                     success = dispatch(url.path, destinations)
                     if self.publisher:
                         self._publish(msg, destinations, success)

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2012-2019
+# Copyright (c) 2012-2020
 #
 # Author(s):
 #
@@ -31,7 +31,6 @@ import glob
 import logging
 import logging.handlers
 import os
-import socket
 import subprocess
 import sys
 import tempfile
@@ -54,7 +53,7 @@ from six.moves.urllib.parse import urlparse
 from trollmoves.client import DEFAULT_REQ_TIMEOUT
 from trollmoves.movers import move_it
 from trollmoves.utils import (clean_url, gen_dict_contains, gen_dict_extract,
-                              get_local_ips)
+                              get_local_ips, is_file_local)
 from trollsift import globify, parse
 
 LOGGER = logging.getLogger(__name__)
@@ -348,8 +347,7 @@ class Listener(Thread):
                 # check that files are local
                 for uri in gen_dict_extract(msg.data, 'uri'):
                     urlobj = urlparse(uri)
-                    if(urlobj.scheme not in ['', 'file']
-                       and not socket.gethostbyname(urlobj.netloc) in get_local_ips()):
+                    if not is_file_local(urlobj):
                         break
                 else:
                     LOGGER.debug('We have a match: %s', str(msg))

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018
+# Copyright (c) 2018, 2020
 
 # Author(s):
 
@@ -21,6 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import netifaces
 from six import string_types
+import socket
 
 from six.moves.urllib.parse import urlparse, urlunparse
 
@@ -123,3 +124,12 @@ def translate_dict(var, keys, callback, **kwargs):
         return newvar
     else:
         return var
+
+
+def is_file_local(urlobj):
+    """Check that a url path is for a local file."""
+    if(urlobj.scheme not in ['', 'file']
+       and not socket.gethostbyname(urlobj.netloc) in get_local_ips()):
+        return False
+
+    return True


### PR DESCRIPTION
Currently trollmove's dispatcher expects a file-path as uri, and does not handle a full url including scheme (ssh, sftp, etc). This PR attempts to solve that.