### PR TITLE
Make filepattern optional

### DIFF
--- a/examples/dispatch.yaml
+++ b/examples/dispatch.yaml
@@ -2,6 +2,8 @@ target1:
   host: ftp://ftp.target1.com
   connection_parameters:
     connection_uptime: 60
+  # File name pattern for the target file.  If not given, the filename
+  #   will be taken from the incoming message 'uid'
   filepattern: '{platform_name}_{start_time}.{format}'
   directory: /input_data/{sensor}
   # Optional direct subscriptions

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,9 @@ release=1
 
 [flake8]
 max-line-length = 120
+ignore =
+    # Unknown directive type "XXX".
+    RST303
 
 [versioneer]
 VCS = git

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -373,14 +373,13 @@ class Dispatcher(Thread):
 
     def create_dest_url(self, msg, client, disp_config):
         """Create the destination URL and the connection parameters."""
-        defaults = self.config[client]
-        defaults.setdefault('filepattern', msg.data['uid'])
+        defaults = self.config[client].copy()
+        if 'filepattern' not in defaults:
+            source_filename = os.path.basename(urlsplit(msg.data['uri']).path)
+            defaults['filepattern'] = source_filename
         info_dict = dict()
         for key in ['host', 'directory', 'filepattern']:
-            try:
-                info_dict[key] = disp_config[key]
-            except KeyError:
-                info_dict[key] = defaults[key]
+            info_dict[key] = disp_config.get(key, defaults[key])
         connection_parameters = disp_config.get(
             'connection_parameters',
             defaults.get('connection_parameters'))

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -328,7 +328,7 @@ class Dispatcher(Thread):
                         # reachable from both). But in those cases one
                         # should probably not use an url scheme but just a
                         # file path:
-                        raise NotImplementedError(("uri is pointing to a file path on another server! " +
+                        raise NotImplementedError(("uri is pointing to a file path on another server! "
                                                    "Host=<%s> uri netloc=<%s>", self.host, url.netloc))
                     success = dispatch(url.path, destinations)
                     if self.publisher:
@@ -374,6 +374,7 @@ class Dispatcher(Thread):
     def create_dest_url(self, msg, client, disp_config):
         """Create the destination URL and the connection parameters."""
         defaults = self.config[client]
+        defaults.setdefault('filepattern', msg.data['uid'])
         info_dict = dict()
         for key in ['host', 'directory', 'filepattern']:
             try:

--- a/trollmoves/tests/test_dispatcher.py
+++ b/trollmoves/tests/test_dispatcher.py
@@ -418,7 +418,8 @@ def test_create_dest_url():
             msg.subject = '/level2/viirs'
             msg.data = {'sensor': 'viirs', 'product': 'green_snow', 'platform_name': 'NOAA-20',
                         'start_time': datetime(2019, 9, 19, 9, 19), 'format': 'tif',
-                        'uid': '201909190919_NOAA-20_viirs.tif'}
+                        'uri': '/data/viirs/201909190919_NOAA-20_viirs.tif',
+                        'uid': '67e91f4a778adc59e5f1a4f0475e388b'}
             # SSH protocol, no username
             url, params, client = dp.create_dest_url(msg, 'target2',
                                                      config['target2'])
@@ -434,10 +435,20 @@ def test_create_dest_url():
             assert url == expected_url
             assert client == "target3"
 
-            # SSH protocol, no filepattern (use uid as target filename)
+            # SSH protocol, no filepattern (use uri as target filename)
             url, params, client = dp.create_dest_url(msg, 'target4',
                                                      config['target4'])
-            expected_url = expected_url = "scp://user@server.target4.com/satellite/viirs/" + msg.data['uid']
+            expected_url = "scp://user@server.target4.com/satellite/viirs/201909190919_NOAA-20_viirs.tif"
+            assert url == expected_url
+
+            msg.data = {'sensor': 'viirs', 'product': 'green_snow', 'platform_name': 'NOAA-20',
+                        'start_time': datetime(2019, 9, 19, 9, 19), 'format': 'tif',
+                        'uri': '/data/viirs/201909190919_SNPP_viirs.tif',
+                        'uid': 'f7a2239df76b17bd85d953447c560812'}
+            # SSH protocol, no filepattern (use uri as target filename), second time
+            url, params, client = dp.create_dest_url(msg, 'target4',
+                                                     config['target4'])
+            expected_url = "scp://user@server.target4.com/satellite/viirs/201909190919_SNPP_viirs.tif"
             assert url == expected_url
 
     finally:


### PR DESCRIPTION
This PR makes `filepattern` an optional config item. If not available, the target filename will be taken from the incoming message `msg.data['uid']`, which is assumed to be available.

Closes #72 