### PR TITLE
Fix keyword argument naming for publisher

### DIFF
--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -21,7 +21,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
+"""Client for Trollmoves.
+
 Moving and unpacking files
 ==========================
 
@@ -90,11 +91,13 @@ LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
 
 
 class MoveItClient(MoveItBase):
+    """Trollmoves client class."""
 
     def __init__(self, cmd_args):
+        """Initialize client."""
         super(MoveItClient, self).__init__(cmd_args, "client")
         self._np = NoisyPublisher("move_it_client")
-        self.sync_pub = self._np.start()
+        self.sync_publisher = self._np.start()
         self.setup_watchers(cmd_args)
 
     def run(self):
@@ -105,13 +108,14 @@ class MoveItClient(MoveItBase):
         self.running = True
         while self.running:
             time.sleep(1)
-            self.sync_pub.heartbeat(30)
+            self.sync_publisher.heartbeat(30)
             for chain_name in self.chains:
                 if not self.chains[chain_name].is_alive():
                     self.chains[chain_name] = self.chains[chain_name].restart()
 
 
 def parse_args():
+    """Parse commandline arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("config_file",
                         help="The configuration file to run on.")
@@ -125,7 +129,7 @@ def parse_args():
 
 
 def main():
-    """Main()"""
+    """Run the Trollmoves Client."""
     cmd_args = parse_args()
     client = MoveItClient(cmd_args)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ max-line-length = 120
 ignore =
     # Unknown directive type "XXX".
     RST303
+    # line break after binary operator
+    W504
 
 [versioneer]
 VCS = git

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -638,10 +638,10 @@ class Chain(Thread):
         except (KeyError, NameError):
             pass
 
-    def setup_listeners(self, callback, sync_pub_instance):
+    def setup_listeners(self, callback, sync_publisher):
         """Set up the listeners."""
         self.callback = callback
-        self.sync_pub_instance = sync_pub_instance
+        self.sync_publisher = sync_publisher
         try:
             topics = []
             if "topic" in self._config:
@@ -666,7 +666,7 @@ class Chain(Thread):
                     provider,
                     topics,
                     callback,
-                    sync_publisher=sync_pub_instance,
+                    sync_publisher=sync_publisher,
                     publisher=self.publisher,
                     die_event=self.listener_died_event,
                     **self._config)
@@ -735,12 +735,12 @@ class Chain(Thread):
         """Restart the chain, return a new running instance."""
         self.stop()
         new_chain = self.__class__(self._name, self._config)
-        new_chain.setup_listeners(self.callback, self.sync_pub_instance)
+        new_chain.setup_listeners(self.callback, self.sync_publisher)
         new_chain.start()
         return new_chain
 
 
-def reload_config(filename, chains, callback=request_push, sync_pub_instance=None):
+def reload_config(filename, chains, callback=request_push, sync_publisher=None):
     """Rebuild chains if needed (if the configuration changed) from *filename*."""
     LOGGER.debug("New config file detected: %s", filename)
 
@@ -760,7 +760,7 @@ def reload_config(filename, chains, callback=request_push, sync_pub_instance=Non
             verb = "Added"
             LOGGER.debug("Adding %s", key)
         chains[key] = Chain(key, new_config)
-        chains[key].setup_listeners(callback, sync_pub_instance)
+        chains[key].setup_listeners(callback, sync_publisher)
         chains[key].start()
 
         LOGGER.debug("%s %s", verb, key)

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -544,7 +544,7 @@ def add_to_file_cache(msg):
                 file_cache.append(uid)
 
 
-def request_push(msg, destination, login=None, sync_publisher=None, **kwargs):
+def request_push(msg, destination, login=None, sync_publisher=None, publisher=None, **kwargs):
     """Request a push for data."""
     huid = add_to_ongoing(msg)
     if huid is None:
@@ -592,7 +592,7 @@ def request_push(msg, destination, login=None, sync_publisher=None, **kwargs):
             except IOError:
                 LOGGER.exception("Couldn't unpack %s", str(response))
                 continue
-            if sync_publisher:
+            if publisher:
                 lmsg = make_uris(lmsg, _destination, login)
                 lmsg.data['origin'] = response.data['request_address']
                 lmsg.data.pop('request_address', None)
@@ -600,7 +600,7 @@ def request_push(msg, destination, login=None, sync_publisher=None, **kwargs):
                 lmsg.data.pop('destination', None)
 
                 LOGGER.debug("publishing %s", str(lmsg))
-                sync_publisher.send(str(lmsg))
+                publisher.send(str(lmsg))
             terminate_transfers(huid, float(kwargs["req_timeout"]))
             break
         else:
@@ -667,6 +667,7 @@ class Chain(Thread):
                     topics,
                     callback,
                     sync_publisher=sync_pub_instance,
+                    publisher=self.publisher,
                     die_event=self.listener_died_event,
                     **self._config)
                 listener.start()

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -666,7 +666,7 @@ class Chain(Thread):
                     provider,
                     topics,
                     callback,
-                    sync_pub_instance=sync_pub_instance,
+                    sync_publisher=sync_pub_instance,
                     die_event=self.listener_died_event,
                     **self._config)
                 listener.start()

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -26,8 +26,6 @@
 import logging
 import logging.handlers
 import os
-import time
-import signal
 
 import pyinotify
 
@@ -47,7 +45,7 @@ class MoveItBase(object):
         self.running = False
         self.notifier = None
         self.watchman = None
-        self.sync_pub = None
+        self.sync_publisher = None
         self._np = None
         self.chains = {}
         setup_logging(cmd_args, chain_type)
@@ -58,12 +56,12 @@ class MoveItBase(object):
         """Reload configuration file."""
         if self.chain_type == "client":
             from trollmoves.client import reload_config
-            reload_config(filename, self.chains, *args, sync_pub_instance=self.sync_pub,
+            reload_config(filename, self.chains, *args, sync_publisher=self.sync_publisher,
                           **kwargs)
         else:
             # Also Mirror uses the reload_config from the Server
             from trollmoves.server import reload_config
-            reload_config(filename, self.chains, *args, publisher=self.sync_pub,
+            reload_config(filename, self.chains, *args, publisher=self.sync_publisher,
                           use_watchdog=self.cmd_args.watchdog,
                           disable_backlog=self.cmd_args.disable_backlog)
 
@@ -73,11 +71,11 @@ class MoveItBase(object):
         if self.chain_type == "client":
             from trollmoves.client import reload_config
             reload_config(self.cmd_args.config_file, self.chains,
-                          sync_pub_instance=self.sync_pub)
+                          sync_publisher=self.sync_publisher)
         else:
             from trollmoves.server import reload_config
             reload_config(self.cmd_args.config_file, self.chains,
-                          publisher=self.sync_pub,
+                          publisher=self.sync_publisher,
                           use_watchdog=self.cmd_args.watchdog,
                           disable_backlog=self.cmd_args.disable_backlog)
 

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -651,7 +651,7 @@ def test_reload_config(Listener, NoisyPublisher):
 
     try:
         reload_config(config_fname_1, chains, callback=callback,
-                      sync_pub_instance='pub')
+                      sync_publisher='pub')
         section_name = "eumetcast_hrit_0deg_scp_hot_spare"
         assert section_name in chains
         listeners = chains[section_name].listeners
@@ -665,7 +665,7 @@ def test_reload_config(Listener, NoisyPublisher):
         chains[section_name].stop()
         # Reload the same config again, nothing should happen
         reload_config(config_fname_1, chains, callback=callback,
-                      sync_pub_instance='pub')
+                      sync_publisher='pub')
         for key in listeners:
             assert listeners[key].start.call_count == 4
         NoisyPublisher.assert_called_once()
@@ -674,7 +674,7 @@ def test_reload_config(Listener, NoisyPublisher):
 
         # Load a new config with one new item
         reload_config(config_fname_2, chains, callback=callback,
-                      sync_pub_instance='pub')
+                      sync_publisher='pub')
         assert len(chains) == 2
         assert "foo" in chains
         # One additional call to publisher and listener
@@ -685,7 +685,7 @@ def test_reload_config(Listener, NoisyPublisher):
 
         # Load the first config again, the other chain should have been removed
         reload_config(config_fname_1, chains, callback=callback,
-                      sync_pub_instance='pub')
+                      sync_publisher='pub')
         assert "foo" not in chains
         # No new calls to publisher nor listener
         assert NoisyPublisher.call_count == 2


### PR DESCRIPTION
This PR fixes a naming issue with a keyword argument passed to `request_push()`.

Closes #77 