### PR TITLE
Fix publisher name for MoveItServer

### DIFF
--- a/bin/move_it_server.py
+++ b/bin/move_it_server.py
@@ -111,7 +111,7 @@ class MoveItServer(MoveItBase):
         """Initialize server."""
         super(MoveItServer, self).__init__(cmd_args, "server")
         LOGGER.info("Starting publisher on port %s.", str(cmd_args.port))
-        self.sync_pub = Publisher("tcp://*:" + str(cmd_args.port), "move_it_server")
+        self.sync_publisher = Publisher("tcp://*:" + str(cmd_args.port), "move_it_server")
 
     def run(self):
         """Start the transfer chains."""
@@ -121,7 +121,7 @@ class MoveItServer(MoveItBase):
         self.running = True
         while self.running:
             time.sleep(1)
-            self.sync_pub.heartbeat(30)
+            self.sync_publisher.heartbeat(30)
 
 
 def parse_args():


### PR DESCRIPTION
This PR fixes one publisher name that was missed in https://github.com/pytroll/trollmoves/pull/76