### PR TITLE
Add configurable poll interval (timeout) to watchdog poller

### DIFF
--- a/examples/move_it_server.ini
+++ b/examples/move_it_server.ini
@@ -1,6 +1,14 @@
 # Start with e.g.
 # move_it_server.py -p 9010 -v move_it_server.ini
 
+[DEFAULT]
+# All default/common values go here.
+# The values defined in individual sections will override these settings.
+station = eumetcast
+# Set watchdog polling timeout (interval) in seconds.
+# Only effective if "-w" commandline argument is given
+# watchdog_timeout = 2.0
+
 [eumetcast-hrit-0deg]
 # Full path and filemask for the advertised data
 origin = /local_disk/tellicast/received/MSGHRIT/H-000-{series:_<6s}-{platform_name:_<12s}-{channel:_<9s}-{segment:_<9s}-{nominal_time:%Y%m%d%H%M}-{compressed:_<2s}

--- a/examples/move_it_server.ini
+++ b/examples/move_it_server.ini
@@ -4,7 +4,10 @@
 [DEFAULT]
 # All default/common values go here.
 # The values defined in individual sections will override these settings.
-station = eumetcast
+
+# Path to SSH _private_ key for key-based identification for ssh transfers
+ssh_key_filename = /home/username/.ssh/id_rsa
+
 # Set watchdog polling timeout (interval) in seconds.
 # Only effective if "-w" commandline argument is given
 # watchdog_timeout = 2.0

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -498,7 +498,9 @@ def create_watchdog_notifier(attrs, publisher):
     pattern = globify(attrs["origin"])
     opath = os.path.dirname(pattern)
 
-    observer = PollingObserver()
+    timeout = float(attrs.get("watchdog_timeout", 1.))
+    LOGGER.debug("Watchdog timeout: %.1f", timeout)
+    observer = PollingObserver(timeout=timeout)
     handler = WatchdogHandler(process_notify, publisher, pattern, attrs)
 
     observer.schedule(handler, opath)

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -56,6 +56,33 @@ def test_create_watchdog_notifier(process_notify):
     fun.assert_called_with(file_path, publisher, globify(pattern_path), attrs)
 
 
+@patch("trollmoves.server.WatchdogHandler")
+@patch("trollmoves.server.PollingObserver")
+@patch("trollmoves.server.process_notify")
+def test_create_watchdog_notifier_timeout(process_notify,
+                                          PollingObserver,
+                                          WatchdogHandler):
+    """Test creating a watchdog notifier."""
+    import time
+    from trollmoves.server import create_watchdog_notifier
+
+    attrs = {"origin": "/tmp"}
+    publisher = ""
+    # No timeout, the default should be used
+    observer, fun = create_watchdog_notifier(attrs, publisher)
+    PollingObserver.assert_called_with(timeout=1.0)
+
+    # User-supplied timeout
+    attrs["watchdog_timeout"] = 2.0
+    observer, fun = create_watchdog_notifier(attrs, publisher)
+    PollingObserver.assert_called_with(timeout=2.0)
+
+    # The timeout is actually a string from the config, so lets test that
+    attrs["watchdog_timeout"] = "3.0"
+    observer, fun = create_watchdog_notifier(attrs, publisher)
+    PollingObserver.assert_called_with(timeout=3.0)
+
+
 @patch("trollmoves.server.Message")
 def test_process_notify(Message):
     """Test process_notify()."""

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -63,7 +63,6 @@ def test_create_watchdog_notifier_timeout(process_notify,
                                           PollingObserver,
                                           WatchdogHandler):
     """Test creating a watchdog notifier."""
-    import time
     from trollmoves.server import create_watchdog_notifier
 
     attrs = {"origin": "/tmp"}


### PR DESCRIPTION
This PR adds a new configuration option for `move_it_server` to lower the polling interval when using `watchdog` notifier (via `-w` command line option). This can lower the CPU usage significantly especially when the monitored directory is mounted over `sshfs`.