### PR TITLE
Ensure transfers are cleared from ongoing transfers after duplicate messages

### DIFF
--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -553,6 +553,7 @@ def request_push(msg, destination, login=None, sync_publisher=None, publisher=No
     if already_received(msg):
         timeout = float(kwargs["req_timeout"])
         send_ack(msg, timeout)
+        _ = clean_ongoing_transfer(huid)
         return
 
     for msg in iterate_messages(huid):


### PR DESCRIPTION
This was an attempt to fix #88 , but in the end didn't help.

With current `master` branch and the latest release, the messages are not cleared from `trollmoves.client.ongoing_transfers` `list` if the message was already fully handled and the file marked as transferred in `trollmoves.client.file_cache` `deque`. This PR makes sure the dictionary of ongoing transfer is cleared also after duplicate messages.
