### PR TITLE
Bugfix spare client requests

### DIFF
--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -82,8 +82,6 @@ import argparse
 import signal
 import time
 
-from posttroll.publisher import NoisyPublisher
-
 from trollmoves.move_it_base import MoveItBase
 from trollmoves.client import StatCollector
 

--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -96,9 +96,6 @@ class MoveItClient(MoveItBase):
     def __init__(self, cmd_args):
         """Initialize client."""
         super(MoveItClient, self).__init__(cmd_args, "client")
-        self._np = NoisyPublisher("move_it_client")
-        self.sync_publisher = self._np.start()
-        self.setup_watchers(cmd_args)
 
     def run(self):
         """Start the transfer chains."""
@@ -108,10 +105,10 @@ class MoveItClient(MoveItBase):
         self.running = True
         while self.running:
             time.sleep(1)
-            self.sync_publisher.heartbeat(30)
             for chain_name in self.chains:
                 if not self.chains[chain_name].is_alive():
                     self.chains[chain_name] = self.chains[chain_name].restart()
+                self.chains[chain_name].publisher.heartbeat(30)
 
 
 def parse_args():

--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -83,6 +83,7 @@ import signal
 import time
 
 from posttroll.publisher import NoisyPublisher
+
 from trollmoves.move_it_base import MoveItBase
 from trollmoves.client import StatCollector
 
@@ -139,6 +140,8 @@ def main():
         client.run()
     except KeyboardInterrupt:
         LOGGER.debug("Interrupting")
+    except Exception as err:
+        LOGGER.exception(err)
     finally:
         if client.running:
             client.chains_stop()

--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -51,7 +51,7 @@ class MoveItMirror(MoveItBase):
     def reload_cfg_file(self, filename):
         """Reload the config file."""
         reload_config(filename, self.chains, self.create_listener_notifier,
-                      MirrorRequestManager, publisher=self.sync_publisher)
+                      MirrorRequestManager, publisher=self.publisher)
 
     def signal_reload_cfg_file(self, *args):
         """Reload the config file when we get a signal."""

--- a/bin/move_it_server.py
+++ b/bin/move_it_server.py
@@ -119,7 +119,7 @@ class MoveItServer(MoveItBase):
         self.running = True
         while self.running:
             time.sleep(1)
-            self.sync_publisher.heartbeat(30)
+            self.publisher.heartbeat(30)
 
 
 def parse_args():

--- a/examples/move_it_client.ini
+++ b/examples/move_it_client.ini
@@ -58,8 +58,9 @@ publish_port = 0
 # Servers to listen, <server>:<port>
 # Use the port number defined with the -p flag for server or mirror
 # The last one is another client that is the primary client, and the messages
-# coming from there need to be also handled
-providers = satmottag2:9010 satmottag:9010 explorer:9010 primary_client
+# coming from there need to be also handled.  For the primary client, use the
+# publish port, which can't be set to 0
+providers = satmottag2:9010 satmottag:9010 explorer:9010 primary_client:<publish_port>
 # Local destination for the data using SCP
 destination = scp:///tmp/foo
 # Login credentials for local SSH server.  Using keys, so no password given

--- a/examples/move_it_client.ini
+++ b/examples/move_it_client.ini
@@ -54,6 +54,8 @@ login = user
 publish_port = 0
 
 # Example acting as a hot spare
+# NOTE: all of the clients are required to have the same section names
+#       as they are used to set the heartbeat publishing topics
 [eumetcast_hrit_0deg_scp]
 # Servers to listen, <server>:<port>
 # Use the port number defined with the -p flag for server or mirror

--- a/examples/move_it_client.ini
+++ b/examples/move_it_client.ini
@@ -55,7 +55,8 @@ publish_port = 0
 
 # Example acting as a hot spare
 # NOTE: all of the clients are required to have the same section names
-#       as they are used to set the heartbeat publishing topics
+#       as they are used to set the heartbeat publishing and subscription
+#       topics for a given data stream
 [eumetcast_hrit_0deg_scp]
 # Servers to listen, <server>:<port>
 # Use the port number defined with the -p flag for server or mirror

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -213,12 +213,22 @@ class Listener(Thread):
                             # client and are not cleared
                             LOGGER.debug("Primary client published 'push'")
                             add_to_ongoing(msg)
+                            continue
 
                         # Handle public "ack" messages as a hot spare client
                         if msg.type == "ack":
                             LOGGER.debug("Primary client finished transfer")
                             _ = add_to_file_cache(msg)
                             _ = clean_ongoing_transfer(get_msg_uid(msg))
+                            continue
+
+                        # Ignore "file" messages which don't have a request address
+                        if msg.type == "file" and "request_address" not in msg.data:
+                            LOGGER.debug("Ignoring 'file' message from primary client.")
+                            add_to_ongoing(msg)
+                            _ = add_to_file_cache(msg)
+                            _ = clean_ongoing_transfer(get_msg_uid(msg))
+                            continue
 
                         # If this is a hot spare client, wait for a while
                         # for a public "push" message which will update

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -63,6 +63,7 @@ ongoing_hot_spare_timers = dict()
 
 DEFAULT_REQ_TIMEOUT = 1
 SERVER_HEARTBEAT_TOPIC = "/heartbeat/move_it_server"
+CLIENT_HEARTBEAT_TOPIC_BASE = "/heartbeat/move_it"
 
 COMPRESSED_ENDINGS = {'xrit': ['C_'],
                       'tar': ['.tar', '.tar.gz', '.tgz', '.tar.bz2'],
@@ -656,6 +657,8 @@ class Chain(Thread):
                 topics.append(self._config["topic"])
             if self._config.get("heartbeat", False):
                 topics.append(SERVER_HEARTBEAT_TOPIC)
+                # Subscribe also to heartbeat messages of other clients
+                topics.append(CLIENT_HEARTBEAT_TOPIC_BASE + '_' + self._name)
             for provider in self._config["providers"]:
                 if '/' in provider.split(':')[-1]:
                     parts = urlparse(provider)

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -180,7 +180,6 @@ class Listener(Thread):
 
                 while self.running:
                     # Loop for restart.
-
                     LOGGER.debug("Starting listener %s", str(self.address))
                     self.create_subscriber()
 

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -46,7 +46,7 @@ class MoveItBase(object):
         self.running = False
         self.notifier = None
         self.watchman = None
-        self.sync_publisher = publisher
+        self.publisher = publisher
         self._np = None
         self.chains = {}
         setup_logging(cmd_args, chain_type)
@@ -57,12 +57,12 @@ class MoveItBase(object):
         """Reload configuration file."""
         if self.chain_type == "client":
             from trollmoves.client import reload_config
-            reload_config(filename, self.chains, *args, sync_publisher=self.sync_publisher,
+            reload_config(filename, self.chains, *args, publisher=self.publisher,
                           **kwargs)
         else:
             # Also Mirror uses the reload_config from the Server
             from trollmoves.server import reload_config
-            reload_config(filename, self.chains, *args, publisher=self.sync_publisher,
+            reload_config(filename, self.chains, *args, publisher=self.publisher,
                           use_watchdog=self.cmd_args.watchdog,
                           disable_backlog=self.cmd_args.disable_backlog)
 
@@ -72,11 +72,11 @@ class MoveItBase(object):
         if self.chain_type == "client":
             from trollmoves.client import reload_config
             reload_config(self.cmd_args.config_file, self.chains,
-                          sync_publisher=self.sync_publisher)
+                          publisher=self.publisher)
         else:
             from trollmoves.server import reload_config
             reload_config(self.cmd_args.config_file, self.chains,
-                          publisher=self.sync_publisher,
+                          publisher=self.publisher,
                           use_watchdog=self.cmd_args.watchdog,
                           disable_backlog=self.cmd_args.disable_backlog)
 

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -57,8 +57,7 @@ class MoveItBase(object):
         """Reload configuration file."""
         if self.chain_type == "client":
             from trollmoves.client import reload_config
-            reload_config(filename, self.chains, *args, publisher=self.publisher,
-                          **kwargs)
+            reload_config(filename, self.chains, *args, **kwargs)
         else:
             # Also Mirror uses the reload_config from the Server
             from trollmoves.server import reload_config

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -653,7 +653,7 @@ def test_reload_config(Listener, NoisyPublisher):
 
     try:
         reload_config(config_fname_1, chains, callback=callback,
-                      sync_publisher='pub')
+                      publisher='pub')
         section_name = "eumetcast_hrit_0deg_scp_hot_spare"
         assert section_name in chains
         listeners = chains[section_name].listeners
@@ -667,7 +667,7 @@ def test_reload_config(Listener, NoisyPublisher):
         chains[section_name].stop()
         # Reload the same config again, nothing should happen
         reload_config(config_fname_1, chains, callback=callback,
-                      sync_publisher='pub')
+                      publisher='pub')
         for key in listeners:
             assert listeners[key].start.call_count == 4
         NoisyPublisher.assert_called_once()
@@ -676,7 +676,7 @@ def test_reload_config(Listener, NoisyPublisher):
 
         # Load a new config with one new item
         reload_config(config_fname_2, chains, callback=callback,
-                      sync_publisher='pub')
+                      publisher='pub')
         assert len(chains) == 2
         assert "foo" in chains
         # One additional call to publisher and listener
@@ -687,7 +687,7 @@ def test_reload_config(Listener, NoisyPublisher):
 
         # Load the first config again, the other chain should have been removed
         reload_config(config_fname_1, chains, callback=callback,
-                      sync_publisher='pub')
+                      publisher='pub')
         assert "foo" not in chains
         # No new calls to publisher nor listener
         assert NoisyPublisher.call_count == 2
@@ -766,8 +766,8 @@ def test_chain(Listener, NoisyPublisher, caplog):
 
     # Setup listeners
     callback = MagicMock()
-    sync_pub_instance = MagicMock()
-    chain.setup_listeners(callback, sync_pub_instance)
+    pub_instance = MagicMock()
+    chain.setup_listeners(callback, pub_instance)
     assert len(chain.listeners) == 4
 
     # Check running with alive listeners


### PR DESCRIPTION
The current version of Trollmoves Client doesn't work properly when a hot-spare Client is used. The spare doesn't receive any of the necessary messages from the primary.

This PR:
- removes unnecessary publishers used for synchronization between the clients (these messages were never received)
- fixes the way different message types were handled
- restructures the unit tests for `trollmoves.client.Listener` class

There still is an issue with the Client stopping when the the config is modified and is reloaded. See https://github.com/pytroll/trollmoves/issues/85 for more information.

 - [x] Tests updated
