### PR TITLE
Prevent unnecessary listener reloads in Trollmoves Client

### DIFF
--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -810,6 +810,8 @@ def reload_config(filename, chains, callback=request_push):
             verb = "Added"
             LOGGER.debug("Adding %s", key)
             chains[key] = Chain(key, new_config)
+            chains[key].start()
+
         chains[key].refresh(new_config, callback)
 
         LOGGER.debug("%s %s", verb, key)

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -795,12 +795,7 @@ def reload_config(filename, chains, callback=request_push):
     new_configs = read_config(filename)
 
     # setup new chains
-
     for key, new_config in new_configs.items():
-        np_ = None
-        publisher = None
-        unchanged_providers = []
-        existing_listeners = {}
         if key in chains:
             if chains[key].config_equals(new_config):
                 continue

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -902,7 +902,6 @@ def test_reload_config_providers_removed(Listener, NoisyPublisher, client_config
         num_providers = len(chains["eumetcast_hrit_0deg_scp_hot_spare"]._config['providers'])
         assert len(chains["eumetcast_hrit_0deg_scp_hot_spare"].listeners) == num_providers
         assert Listener.call_count == num_providers
-        old_listeners = chains["eumetcast_hrit_0deg_scp_hot_spare"].listeners
         reload_config(client_config_1_item_two_providers, chains, callback=callback)
         num_providers2 = len(chains["eumetcast_hrit_0deg_scp_hot_spare"]._config['providers'])
         assert num_providers2 != num_providers

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -920,7 +920,7 @@ def test_reload_config_provider_topic_changed(Listener, NoisyPublisher, client_c
         reload_config(client_config_1_item, chains, callback=callback)
         num_providers = _check_providers_listeners_and_listener_calls(chains, Listener)
         reload_config(client_config_1_item_topic_changed, chains, callback=callback)
-        num_providers2 = _check_providers_listeners_and_listener_calls(chains, Listener, call_count = 2 * num_providers)
+        num_providers2 = _check_providers_listeners_and_listener_calls(chains, Listener, call_count=2 * num_providers)
         assert num_providers2 == num_providers
     finally:
         _stop_chains(chains)


### PR DESCRIPTION
The listeners in Trollmoves Client were restarted whenever the config file was modified. This could potentially mean that some of the messages were not received. This PR restructures the Client code so that this doesn't happen anymore.

With this PR the Client listeners are recreated only if their settings (provider address/port, topic) are changed. Providers can be added and removed without interruptions.

 - [x] Closes #97  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
