### PR TITLE
Remove client listener callback

### DIFF
--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -83,7 +83,6 @@ import signal
 import time
 
 from trollmoves.move_it_base import MoveItBase
-from trollmoves.client import StatCollector
 
 LOGGER = logging.getLogger("move_it_client")
 LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
@@ -117,8 +116,6 @@ def parse_args():
                         help="The configuration file to run on.")
     parser.add_argument("-l", "--log",
                         help="The file to log to. stdout otherwise.")
-    parser.add_argument("-s", "--stats",
-                        help="Save stats to this file")
     parser.add_argument("-v", "--verbose", default=False, action="store_true",
                         help="Toggle verbose logging")
     return parser.parse_args()
@@ -130,11 +127,7 @@ def main():
     client = MoveItClient(cmd_args)
 
     try:
-        if cmd_args.stats:
-            stat = StatCollector(cmd_args.stats)
-            client.reload_cfg_file(cmd_args.config_file, callback=stat.collect)
-        else:
-            client.reload_cfg_file(cmd_args.config_file)
+        client.reload_cfg_file(cmd_args.config_file)
         client.run()
     except KeyboardInterrupt:
         LOGGER.debug("Interrupting")

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -919,33 +919,6 @@ class PushRequester(object):
 
         return rep
 
-# Generic event handler
-
-
-class EventHandler(pyinotify.ProcessEvent):
-    """Handle events with a generic *fun* function."""
-
-    def __init__(self, fun, *args, **kwargs):
-        """Initialize handler."""
-        pyinotify.ProcessEvent.__init__(self, *args, **kwargs)
-        self._fun = fun
-
-    def process_IN_CLOSE_WRITE(self, event):
-        """Process on closing after writing."""
-        self._fun(event.pathname)
-
-    def process_IN_CREATE(self, event):
-        """Process on closing after linking."""
-        try:
-            if os.stat(event.pathname).st_nlink > 1:
-                self._fun(event.pathname)
-        except OSError:
-            return
-
-    def process_IN_MOVED_TO(self, event):
-        """Process on closing after moving."""
-        self._fun(event.pathname)
-
 
 def terminate(chains):
     """Terminate client chains."""

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -947,19 +947,6 @@ class EventHandler(pyinotify.ProcessEvent):
         self._fun(event.pathname)
 
 
-class StatCollector(object):
-    """StatCollector class."""
-
-    def __init__(self, statfile):
-        """Initialize collector."""
-        self.statfile = statfile
-
-    def collect(self, msg, *args, **kwargs):
-        """Collect."""
-        with open(self.statfile, 'a') as fd:
-            fd.write(time.asctime() + " - " + str(msg) + "\n")
-
-
 def terminate(chains):
     """Terminate client chains."""
     for chain in chains.values():

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -137,12 +137,11 @@ def read_config(filename):
 class Listener(Thread):
     """PyTroll listener class for reading messages for Trollduction."""
 
-    def __init__(self, address, topics, callback, *args, die_event=None, **kwargs):
+    def __init__(self, address, topics, *args, die_event=None, **kwargs):
         """Init Listener object."""
         super(Listener, self).__init__()
 
         self.topics = topics
-        self.callback = callback
         self.subscriber = None
         self.address = address
         self.running = False
@@ -156,7 +155,7 @@ class Listener(Thread):
     def restart(self):
         """Restart the listener, returns a new running instance."""
         self.stop()
-        new_listener = self.__class__(self.address, self.topics, self.callback, *self.cargs,
+        new_listener = self.__class__(self.address, self.topics, *self.cargs,
                                       die_event=self.die_event, **self.ckwargs)
         new_listener.death_count = self.death_count + 1
         new_listener.start()
@@ -235,10 +234,10 @@ class Listener(Thread):
                         # the ongoing transfers before starting processing here
                         delay = self.ckwargs.get("processing_delay", False)
                         if delay:
-                            add_timer(float(delay), self.callback, msg, *self.cargs,
+                            add_timer(float(delay), request_push, msg, *self.cargs,
                                       **self.ckwargs)
                         else:
-                            self.callback(msg, *self.cargs, **self.ckwargs)
+                            request_push(msg, *self.cargs, **self.ckwargs)
 
                     LOGGER.debug("Exiting listener %s", str(self.address))
         except Exception as err:
@@ -513,12 +512,12 @@ def get_next_msg(uid):
         return ongoing_transfers[uid].pop(0)
 
 
-def add_timer(timeout, callback, msg, *args, **kwargs):
+def add_timer(timeout, func, msg, *args, **kwargs):
     """Add a timer for hot spare."""
     huid = get_msg_uid(msg)
     cargs = [msg] + list(args)
     with hot_spare_timer_lock:
-        timer = CTimer(timeout, callback, args=cargs, kwargs=kwargs)
+        timer = CTimer(timeout, func, args=cargs, kwargs=kwargs)
         ongoing_hot_spare_timers[huid] = timer
         ongoing_hot_spare_timers[huid].start()
     LOGGER.debug("Added timer for UID %s.", huid)
@@ -649,9 +648,8 @@ class Chain(Thread):
             except (KeyError, NameError):
                 pass
 
-    def setup_listeners(self, callback, keep_providers=None):
+    def setup_listeners(self, keep_providers=None):
         """Set up the listeners."""
-        self.callback = callback
         keep_providers = keep_providers or []
         try:
             topics = []
@@ -681,7 +679,6 @@ class Chain(Thread):
                 listener = Listener(
                     provider,
                     topics,
-                    callback,
                     publisher=self.publisher,
                     die_event=self.listener_died_event,
                     **self._config)
@@ -746,14 +743,14 @@ class Chain(Thread):
                 return True
         return False
 
-    def refresh(self, new_config, callback):
+    def refresh(self, new_config):
         """Refresh the chain with new config."""
         publisher_needs_restarting = self.publisher_needs_restarting(new_config)
         unchanged_providers = self.get_unchanged_providers(new_config)
         self._config = new_config
         if publisher_needs_restarting:
             self._refresh_publisher()
-        self._refresh_listeners(callback, unchanged_providers)
+        self._refresh_listeners(unchanged_providers)
         if not self.running:
             self.start()
 
@@ -761,9 +758,9 @@ class Chain(Thread):
         self._stop_publisher()
         self.setup_publisher()
 
-    def _refresh_listeners(self, callback, unchanged_providers):
+    def _refresh_listeners(self, unchanged_providers):
         self.reset_listeners(keep_providers=unchanged_providers)
-        self.setup_listeners(callback, keep_providers=unchanged_providers)
+        self.setup_listeners(keep_providers=unchanged_providers)
 
     def reset_listeners(self, keep_providers=None):
         """Reset the listeners."""
@@ -791,12 +788,12 @@ class Chain(Thread):
         """Restart the chain, return a new running instance."""
         self.stop()
         new_chain = self.__class__(self._name, self._config)
-        new_chain.setup_listeners(self.callback)
+        new_chain.setup_listeners()
         new_chain.start()
         return new_chain
 
 
-def reload_config(filename, chains, callback=request_push):
+def reload_config(filename, chains):
     """Rebuild chains if needed (if the configuration changed) from *filename*."""
     LOGGER.debug("New config file detected: %s", filename)
 
@@ -815,7 +812,7 @@ def reload_config(filename, chains, callback=request_push):
             chains[key] = Chain(key, new_config)
             chains[key].start()
 
-        chains[key].refresh(new_config, callback)
+        chains[key].refresh(new_config)
 
         LOGGER.debug("%s %s", verb, key)
 

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -37,7 +37,6 @@ import subprocess
 from contextlib import suppress
 
 import tarfile
-import pyinotify
 from zmq import LINGER, POLLIN, REQ, Poller
 import bz2
 from posttroll import get_context

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -155,24 +155,22 @@ CHAIN_BASIC_CONFIG = {"login": "user:pass", "topic": "/foo", "publish_port": 123
 
 @pytest.fixture
 def listener():
-    callback = MagicMock()
     with patch('trollmoves.client.CTimer'):
         with patch('trollmoves.heartbeat_monitor.Monitor'):
             with patch('trollmoves.client.Subscriber'):
                 from trollmoves.client import Listener
-                listener = Listener('127.0.0.1:0', ['/topic'], callback, 'arg1', 'arg2',
+                listener = Listener('127.0.0.1:0', ['/topic'], 'arg1', 'arg2',
                                     kwarg1='kwarg1', kwarg2='kwarg2')
                 yield listener
 
 
 @pytest.fixture
 def delayed_listener():
-    callback = MagicMock()
     with patch('trollmoves.client.CTimer'):
         with patch('trollmoves.heartbeat_monitor.Monitor'):
             with patch('trollmoves.client.Subscriber'):
                 from trollmoves.client import Listener
-                listener = Listener('127.0.0.1:0', ['/topic'], callback, 'arg1', 'arg2',
+                listener = Listener('127.0.0.1:0', ['/topic'], 'arg1', 'arg2',
                                     processing_delay=0.02,
                                     kwarg1='kwarg1', kwarg2='kwarg2')
                 yield listener
@@ -587,10 +585,10 @@ def test_unpack_and_create_local_message_config_xrit_compression(unpackers, comp
         os.remove(compression_config)
 
 
-def test_listener_init(delayed_listener):
+@patch('trollmoves.client.request_push')
+def test_listener_init(request_push, delayed_listener):
     """Test listener init."""
     assert delayed_listener.topics == ['/topic']
-    assert delayed_listener.callback is not None
     assert delayed_listener.subscriber is None
     assert delayed_listener.address == '127.0.0.1:0'
     assert delayed_listener.running is False
@@ -600,9 +598,10 @@ def test_listener_init(delayed_listener):
         assert kwargs[key] == itm
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.add_to_ongoing')
 @patch('trollmoves.client.add_to_file_cache')
-def test_listener_push_message(add_to_file_cache, add_to_ongoing, delayed_listener):
+def test_listener_push_message(add_to_file_cache, add_to_ongoing, request_push, delayed_listener):
     """Test listener push message."""
     delayed_listener.create_subscriber()
     delayed_listener.subscriber.return_value = [MSG_PUSH]
@@ -613,9 +612,10 @@ def test_listener_push_message(add_to_file_cache, add_to_ongoing, delayed_listen
     add_to_ongoing.assert_called_with(MSG_PUSH)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.clean_ongoing_transfer')
 @patch('trollmoves.client.add_to_file_cache')
-def test_listener_ack_message(add_to_file_cache, clean_ongoing_transfer, delayed_listener):
+def test_listener_ack_message(add_to_file_cache, clean_ongoing_transfer, request_push, delayed_listener):
     """Test listener with ack message."""
     delayed_listener.create_subscriber()
     delayed_listener.subscriber.return_value = [MSG_ACK]
@@ -626,11 +626,13 @@ def test_listener_ack_message(add_to_file_cache, clean_ongoing_transfer, delayed
     add_to_file_cache.assert_called_with(MSG_ACK)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.add_timer')
 @patch('trollmoves.client.add_to_ongoing')
 @patch('trollmoves.client.clean_ongoing_transfer')
 @patch('trollmoves.client.add_to_file_cache')
-def test_listener_beat_message(add_to_file_cache, clean_ongoing_transfer, add_to_ongoing, add_timer, delayed_listener):
+def test_listener_beat_message(add_to_file_cache, clean_ongoing_transfer, add_to_ongoing, add_timer, request_push,
+                               delayed_listener):
     """Test listener with beat message."""
     delayed_listener.create_subscriber()
     delayed_listener.subscriber.return_value = [MSG_BEAT]
@@ -643,13 +645,14 @@ def test_listener_beat_message(add_to_file_cache, clean_ongoing_transfer, add_to
     clean_ongoing_transfer.assert_not_called()
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.add_timer')
 @patch('trollmoves.client.add_to_ongoing')
 @patch('trollmoves.client.clean_ongoing_transfer')
 @patch('trollmoves.client.add_to_file_cache')
 @patch('trollmoves.client.CTimer')
 def test_listener_sync_file_message(
-        CTimer, add_to_file_cache, clean_ongoing_transfer, add_to_ongoing, add_timer, delayed_listener):
+        CTimer, add_to_file_cache, clean_ongoing_transfer, add_to_ongoing, add_timer, request_push, delayed_listener):
     """Test listener with a file message from another client."""
     from trollmoves.client import get_msg_uid
 
@@ -665,8 +668,9 @@ def test_listener_sync_file_message(
     add_timer.assert_not_called()
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.CTimer')
-def test_listener_file_message(CTimer, delayed_listener):
+def test_listener_file_message(CTimer, request_push, delayed_listener):
     """Test listener with a file message from Trollmoves Server."""
     delayed_listener.create_subscriber()
     delayed_listener.subscriber.return_value = [MSG_FILE2]
@@ -675,20 +679,22 @@ def test_listener_file_message(CTimer, delayed_listener):
     CTimer.assert_called()
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.add_timer')
-def test_listener_no_delay_file_message(add_timer, listener):
+def test_listener_no_delay_file_message(add_timer, request_push, listener):
     """Test listener without a delay receiving a file message."""
     listener.create_subscriber()
     listener.subscriber.return_value = [MSG_FILE2]
 
     _run_listener_in_thread(listener)
 
-    listener.callback.assert_called_with(MSG_FILE2, 'arg1', 'arg2',
-                                         kwarg1='kwarg1', kwarg2='kwarg2')
+    request_push.assert_called_with(MSG_FILE2, 'arg1', 'arg2',
+                                    kwarg1='kwarg1', kwarg2='kwarg2')
     add_timer.assert_not_called()
 
 
-def test_listener_stop(listener):
+@patch('trollmoves.client.request_push')
+def test_listener_stop(request_push, listener):
     """Test stopping the listener."""
     listener.create_subscriber()
     assert listener.subscriber is not None
@@ -908,17 +914,17 @@ def test_read_config(client_config_1_item):
     assert isinstance(conf[section_name]["providers"], list)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_single_chain(Listener, NoisyPublisher, client_config_1_item):
+def test_reload_config_single_chain(Listener, NoisyPublisher, request_push, client_config_1_item):
     """Test trollmoves.client.reload_config() with a single chain."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         assert len(chains) == 1
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
         assert NoisyPublisher.call_count == 1
@@ -928,18 +934,18 @@ def test_reload_config_single_chain(Listener, NoisyPublisher, client_config_1_it
         os.remove(client_config_1_item)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_chain_added(Listener, NoisyPublisher, client_config_1_item, client_config_2_items):
+def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, client_config_1_item, client_config_2_items):
     """Test trollmoves.client.reload_config() when a chain is added."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
-        reload_config(client_config_2_items, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
+        reload_config(client_config_2_items, chains)
         assert len(chains) == 2
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
         assert "foo" in chains
@@ -951,18 +957,18 @@ def test_reload_config_chain_added(Listener, NoisyPublisher, client_config_1_ite
         os.remove(client_config_2_items)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_chain_removed(Listener, NoisyPublisher, client_config_1_item, client_config_2_items):
+def test_reload_config_chain_removed(Listener, NoisyPublisher, request_push, client_config_1_item, client_config_2_items):
     """Test trollmoves.client.reload_config() when a chain is added."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_2_items, chains, callback=callback)
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_2_items, chains)
+        reload_config(client_config_1_item, chains)
         assert len(chains) == 1
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
         assert "foo" not in chains
@@ -982,20 +988,20 @@ def _stop_chains(chains):
             pass
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, client_config_1_item,
+def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
                                                    client_config_1_item_non_pub_provider_item_modified):
     """Test trollmoves.client.reload_config() when other than publisher related items are changed."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         NoisyPublisher.assert_called_once()
-        reload_config(client_config_1_item_non_pub_provider_item_modified, chains, callback=callback)
+        reload_config(client_config_1_item_non_pub_provider_item_modified, chains)
         NoisyPublisher.assert_called_once()
     finally:
         _stop_chains(chains)
@@ -1003,20 +1009,20 @@ def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, cli
         os.remove(client_config_1_item_non_pub_provider_item_modified)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, client_config_1_item,
+def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
                                                client_config_1_pub_item_modified):
     """Test trollmoves.client.reload_config() when publisher related items are changed."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         NoisyPublisher.assert_called_once()
-        reload_config(client_config_1_pub_item_modified, chains, callback=callback)
+        reload_config(client_config_1_pub_item_modified, chains)
         assert NoisyPublisher.call_count == 2
     finally:
         _stop_chains(chains)
@@ -1024,21 +1030,21 @@ def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, client_
         os.remove(client_config_1_pub_item_modified)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_not_changed(Listener, NoisyPublisher, client_config_1_item,
+def test_reload_config_providers_not_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
                                              client_config_1_item_non_pub_provider_item_modified):
     """Test trollmoves.client.reload_config() when other than provider related options are changed."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         num_providers = len(chains["eumetcast_hrit_0deg_scp_hot_spare"]._config['providers'])
         assert Listener.call_count == num_providers
-        reload_config(client_config_1_item_non_pub_provider_item_modified, chains, callback=callback)
+        reload_config(client_config_1_item_non_pub_provider_item_modified, chains)
         assert Listener.call_count == num_providers
     finally:
         _stop_chains(chains)
@@ -1046,20 +1052,20 @@ def test_reload_config_providers_not_changed(Listener, NoisyPublisher, client_co
         os.remove(client_config_1_item_non_pub_provider_item_modified)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_added(Listener, NoisyPublisher, client_config_1_item,
+def test_reload_config_providers_added(Listener, NoisyPublisher, request_push, client_config_1_item,
                                        client_config_1_item_two_providers):
     """Test trollmoves.client.reload_config() when providers are added."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item_two_providers, chains, callback=callback)
+        reload_config(client_config_1_item_two_providers, chains)
         _ = _check_providers_listeners_and_listener_calls(chains, Listener)
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         _ = _check_providers_listeners_and_listener_calls(chains, Listener)
     finally:
         _stop_chains(chains)
@@ -1076,9 +1082,10 @@ def _check_providers_listeners_and_listener_calls(chains, Listener, call_count=N
     return num_providers
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_removed(Listener, NoisyPublisher, client_config_1_item,
+def test_reload_config_providers_removed(Listener, NoisyPublisher, request_push, client_config_1_item,
                                          client_config_1_item_two_providers):
     """Test trollmoves.client.reload_config() when providers are removed."""
     from trollmoves.client import reload_config
@@ -1087,12 +1094,11 @@ def test_reload_config_providers_removed(Listener, NoisyPublisher, client_config
     Listener.return_value = listener
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         num_providers = _check_providers_listeners_and_listener_calls(chains, Listener)
-        reload_config(client_config_1_item_two_providers, chains, callback=callback)
+        reload_config(client_config_1_item_two_providers, chains)
         num_providers2 = _check_providers_listeners_and_listener_calls(chains, Listener, call_count=num_providers)
         assert num_providers2 != num_providers
         assert listener.stop.call_count == num_providers - num_providers2
@@ -1102,20 +1108,20 @@ def test_reload_config_providers_removed(Listener, NoisyPublisher, client_config
         os.remove(client_config_1_item_two_providers)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_provider_topic_changed(Listener, NoisyPublisher, client_config_1_item,
+def test_reload_config_provider_topic_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
                                               client_config_1_item_topic_changed):
     """Test trollmoves.client.reload_config() when the message topic is changed."""
     from trollmoves.client import reload_config
 
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         num_providers = _check_providers_listeners_and_listener_calls(chains, Listener)
-        reload_config(client_config_1_item_topic_changed, chains, callback=callback)
+        reload_config(client_config_1_item_topic_changed, chains)
         num_providers2 = _check_providers_listeners_and_listener_calls(chains, Listener, call_count=2 * num_providers)
         assert num_providers2 == num_providers
     finally:
@@ -1124,8 +1130,9 @@ def test_reload_config_provider_topic_changed(Listener, NoisyPublisher, client_c
         os.remove(client_config_1_item_topic_changed)
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.Chain')
-def test_reload_config_chain_not_recreated(Chain, client_config_1_item, client_config_1_pub_item_modified):
+def test_reload_config_chain_not_recreated(Chain, request_push, client_config_1_item, client_config_1_pub_item_modified):
     """Test that the chain is not recreated when config is modified."""
     from trollmoves.client import reload_config
 
@@ -1135,12 +1142,11 @@ def test_reload_config_chain_not_recreated(Chain, client_config_1_item, client_c
     chain.config_equals = config_equals
     Chain.return_value = chain
     chains = {}
-    callback = MagicMock()
 
     try:
-        reload_config(client_config_1_item, chains, callback=callback)
+        reload_config(client_config_1_item, chains)
         Chain.assert_called_once()
-        reload_config(client_config_1_pub_item_modified, chains, callback=callback)
+        reload_config(client_config_1_pub_item_modified, chains)
         Chain.assert_called_once()
     finally:
         os.remove(client_config_1_item)
@@ -1214,35 +1220,35 @@ def test_chain_init(Listener, NoisyPublisher, chain_config_with_one_item):
     assert not chain.listener_died_event.is_set()
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_chain_listeners(Listener, NoisyPublisher, chain_config_with_one_item):
+def test_chain_listeners(Listener, NoisyPublisher, request_push, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
 
     _mock_listener_for_chain_tests(Listener)
-    callback = MagicMock()
 
     name = 'eumetcast_hrit_0deg_scp_hot_spare'
     chain = Chain(name, chain_config_with_one_item[name])
-    chain.setup_listeners(callback)
+    chain.setup_listeners()
 
     assert len(chain.listeners) == 4
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_chain_restart_dead_listeners(Listener, NoisyPublisher, caplog, chain_config_with_one_item):
+def test_chain_restart_dead_listeners(Listener, NoisyPublisher, request_push, caplog, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
     import trollmoves.client
 
     _mock_listener_for_chain_tests(Listener)
-    callback = MagicMock()
 
     name = 'eumetcast_hrit_0deg_scp_hot_spare'
     chain = Chain(name, chain_config_with_one_item[name])
-    chain.setup_listeners(callback)
+    chain.setup_listeners()
 
     with patch('trollmoves.client.LISTENER_CHECK_INTERVAL', new=.1):
         trollmoves.client.LISTENER_CHECK_INTERVAL = .1
@@ -1263,19 +1269,19 @@ def test_chain_restart_dead_listeners(Listener, NoisyPublisher, caplog, chain_co
             chain.stop()
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_chain_listener_crashing_once(Listener, NoisyPublisher, caplog, chain_config_with_one_item):
+def test_chain_listener_crashing_once(Listener, NoisyPublisher, request_push, caplog, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
     import trollmoves.client
 
     _mock_listener_for_chain_tests(Listener)
-    callback = MagicMock()
 
     name = 'eumetcast_hrit_0deg_scp_hot_spare'
     chain = Chain(name, chain_config_with_one_item[name])
-    chain.setup_listeners(callback)
+    chain.setup_listeners()
 
     with patch('trollmoves.client.LISTENER_CHECK_INTERVAL', new=.1):
         trollmoves.client.LISTENER_CHECK_INTERVAL = .1
@@ -1293,9 +1299,10 @@ def test_chain_listener_crashing_once(Listener, NoisyPublisher, caplog, chain_co
             chain.stop()
 
 
+@patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_chain_listener_crashing_all_the_time(Listener, NoisyPublisher, caplog, chain_config_with_one_item):
+def test_chain_listener_crashing_all_the_time(Listener, NoisyPublisher, request_push, caplog, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
     import trollmoves.client
@@ -1304,11 +1311,10 @@ def test_chain_listener_crashing_all_the_time(Listener, NoisyPublisher, caplog, 
         return Listener
 
     _mock_listener_for_chain_tests(Listener, is_alive=False)
-    callback = MagicMock()
 
     name = 'eumetcast_hrit_0deg_scp_hot_spare'
     chain = Chain(name, chain_config_with_one_item[name])
-    chain.setup_listeners(callback)
+    chain.setup_listeners()
 
     with patch('trollmoves.client.LISTENER_CHECK_INTERVAL', new=.1):
         trollmoves.client.LISTENER_CHECK_INTERVAL = .1

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -960,7 +960,8 @@ def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, clien
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_reload_config_chain_removed(Listener, NoisyPublisher, request_push, client_config_1_item, client_config_2_items):
+def test_reload_config_chain_removed(Listener, NoisyPublisher, request_push,
+                                     client_config_1_item, client_config_2_items):
     """Test trollmoves.client.reload_config() when a chain is added."""
     from trollmoves.client import reload_config
 
@@ -1132,7 +1133,8 @@ def test_reload_config_provider_topic_changed(Listener, NoisyPublisher, request_
 
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.Chain')
-def test_reload_config_chain_not_recreated(Chain, request_push, client_config_1_item, client_config_1_pub_item_modified):
+def test_reload_config_chain_not_recreated(Chain, request_push, client_config_1_item,
+                                           client_config_1_pub_item_modified):
     """Test that the chain is not recreated when config is modified."""
     from trollmoves.client import reload_config
 
@@ -1302,7 +1304,8 @@ def test_chain_listener_crashing_once(Listener, NoisyPublisher, request_push, ca
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.NoisyPublisher')
 @patch('trollmoves.client.Listener')
-def test_chain_listener_crashing_all_the_time(Listener, NoisyPublisher, request_push, caplog, chain_config_with_one_item):
+def test_chain_listener_crashing_all_the_time(Listener, NoisyPublisher, request_push,
+                                              caplog, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
     import trollmoves.client


### PR DESCRIPTION
In a continued effort to make Trollmoves easier to maintain, this PR removes the callback mechanism from the Client. In the same go, the unused `trollmoves.client.StatCollector` is removed.

 - [x] Tests updated
