### PR TITLE
Refactor mirror

### DIFF
--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -23,120 +23,12 @@
 """Move it Mirror."""
 
 import logging.handlers
-from threading import Lock, Timer
-from urllib.parse import urlunparse
 import argparse
 
-from posttroll.message import Message
-from posttroll.publisher import get_own_ip
-
-from trollmoves.move_it_base import MoveItBase, create_publisher
-from trollmoves.client import Listener
-from trollmoves.server import reload_config
-from trollmoves.mirror import MirrorRequestManager, file_registry
+from trollmoves.mirror import MoveItMirror
 
 LOGGER = logging.getLogger("move_it_mirror")
 LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
-
-
-class MoveItMirror(MoveItBase):
-    """Mirror for move_it."""
-
-    def __init__(self, cmd_args):
-        """Set up the mirror."""
-        publisher = create_publisher(cmd_args.port, "move_it_mirror")
-        super(MoveItMirror, self).__init__(cmd_args, "mirror", publisher=publisher)
-        self.cache_lock = Lock()
-
-    def reload_cfg_file(self, filename):
-        """Reload the config file."""
-        reload_config(filename, self.chains, self.create_listener_notifier,
-                      MirrorRequestManager, publisher=self.publisher)
-
-    def signal_reload_cfg_file(self, *args):
-        """Reload the config file when we get a signal."""
-        del args
-        self.reload_cfg_file(self.cmd_args.config_file)
-
-    def create_listener_notifier(self, attrs, publisher):
-        """Create a listener notifier."""
-        request_address = attrs.get("request_address",
-                                    get_own_ip()) + ":" + attrs["request_port"]
-
-        delay = float(attrs.get('delay', 0))
-        if delay > 0:
-            def send(msg):
-                """Delay the sending."""
-                Timer(delay, publisher.send, [msg]).start()
-        else:
-            def send(msg):
-                """Use the regular publisher to send."""
-                publisher.send(msg)
-
-        def publish_callback(msg, *args, **kwargs):
-            """Forward an updated message."""
-            del args
-            del kwargs
-            # save to file_cache
-            with self.cache_lock:
-                if msg.data['uid'] in file_registry:
-                    file_registry[msg.data['uid']].append(msg)
-                    return
-
-            file_registry[msg.data['uid']] = [msg]
-            # transform message
-            new_msg = Message(msg.subject, msg.type, msg.data.copy())
-            new_msg.data['request_address'] = request_address
-
-            # send onwards
-            LOGGER.debug('Sending %s', str(new_msg))
-            send(str(new_msg))
-
-        if "client_topic" not in attrs:
-            attrs["client_topic"] = None
-        listeners = Listeners(publish_callback, **attrs)
-
-        return listeners, foo
-
-
-def foo(*args, **kwargs):
-    """Do not do anything."""
-    pass
-
-
-class Listeners(object):
-    """Class for multiple listeners."""
-
-    def __init__(self, callback, client_topic, providers, **attrs):
-        """Set up the listeners."""
-        self.listeners = []
-        if client_topic is None:
-            client_topic = []
-        else:
-            client_topic = [client_topic]
-
-        for provider in providers.split():
-            topic = client_topic
-            if '/' in provider:
-                parts = provider.split('/', 1)
-                provider = parts[0]
-                topic = ['/' + parts[1]]
-                LOGGER.info("Using provider-specific topic %s for %s",
-                            topic, provider)
-            self.listeners.append(Listener(
-                urlunparse(('tcp', provider, '', '', '', '')),
-                topic,
-                callback, **attrs))
-
-    def start(self):
-        """Start the listeners."""
-        for listener in self.listeners:
-            listener.start()
-
-    def stop(self):
-        """Stop the listeners."""
-        for listener in self.listeners:
-            listener.stop()
 
 
 def parse_args():

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -488,12 +488,15 @@ def make_uris(msg, destination, login=None):
 
 
 def replace_mda(msg, kwargs):
-    """Replace messate metadata with itmes in kwargs dict."""
+    """Replace messate metadata with items in kwargs dict."""
     for key in msg.data:
         if key in kwargs:
-            replacement = dict(item.split(':')
-                               for item in kwargs[key].split('|'))
-            msg.data[key] = replacement[msg.data[key]]
+            try:
+                replacement = dict(item.split(':') for item in kwargs[key].split('|'))
+                replacement = replacement[msg.data[key]]
+            except ValueError:
+                replacement = kwargs[key]
+            msg.data[key] = replacement
     return msg
 
 

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -23,14 +23,128 @@
 """All you need for mirroring."""
 
 import os
+import logging
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
+from threading import Lock, Timer
 
+from posttroll.message import Message
+from posttroll.publisher import get_own_ip
+
+from trollmoves.client import Listener
 from trollmoves.client import request_push
 from trollmoves.server import RequestManager, Deleter
+from trollmoves.move_it_base import MoveItBase, create_publisher
+from trollmoves.server import reload_config
 
-# FIXME: don't use globals
+
+LOGGER = logging.getLogger(__name__)
 file_registry = {}
+
+
+class MoveItMirror(MoveItBase):
+    """Mirror for move_it."""
+
+    def __init__(self, cmd_args):
+        """Set up the mirror."""
+        publisher = create_publisher(cmd_args.port, "move_it_mirror")
+        super(MoveItMirror, self).__init__(cmd_args, "mirror", publisher=publisher)
+        self.cache_lock = Lock()
+
+    def reload_cfg_file(self, filename):
+        """Reload the config file."""
+        reload_config(filename, self.chains, self.create_listener_notifier,
+                      MirrorRequestManager, publisher=self.publisher)
+
+    def signal_reload_cfg_file(self, *args):
+        """Reload the config file when we get a signal."""
+        del args
+        self.reload_cfg_file(self.cmd_args.config_file)
+
+    def create_listener_notifier(self, attrs, publisher):
+        """Create a listener notifier."""
+        request_address = attrs.get("request_address",
+                                    get_own_ip()) + ":" + attrs["request_port"]
+
+        delay = float(attrs.get('delay', 0))
+        if delay > 0:
+            def send(msg):
+                """Delay the sending."""
+                Timer(delay, publisher.send, [msg]).start()
+        else:
+            def send(msg):
+                """Use the regular publisher to send."""
+                publisher.send(msg)
+
+        def publish_callback(msg, *args, **kwargs):
+            """Forward an updated message."""
+            del args
+            del kwargs
+            # save to file_cache
+            with self.cache_lock:
+                if msg.data['uid'] in file_registry:
+                    file_registry[msg.data['uid']].append(msg)
+                    return
+
+            file_registry[msg.data['uid']] = [msg]
+            # transform message
+            new_msg = Message(msg.subject, msg.type, msg.data.copy())
+            new_msg.data['request_address'] = request_address
+
+            # send onwards
+            LOGGER.debug('Sending %s', str(new_msg))
+            send(str(new_msg))
+
+        if "client_topic" not in attrs:
+            attrs["client_topic"] = None
+        listeners = Listeners(publish_callback, **attrs)
+
+        return listeners, noop
+
+
+def noop(*args, **kwargs):
+    """Do not do anything."""
+    pass
+
+
+class Listeners(object):
+    """Class for multiple listeners."""
+
+    def __init__(self, callback, client_topic, providers, **attrs):
+        """Set up the listeners."""
+        self.listeners = []
+        if client_topic is None:
+            client_topic = []
+        else:
+            client_topic = [client_topic]
+
+        for provider in providers.split():
+            topic = _get_topic(client_topic, provider)
+            self.listeners.append(Listener(
+                urlunparse(('tcp', provider, '', '', '', '')),
+                topic,
+                callback, **attrs))
+
+    def start(self):
+        """Start the listeners."""
+        for listener in self.listeners:
+            listener.start()
+
+    def stop(self):
+        """Stop the listeners."""
+        for listener in self.listeners:
+            listener.stop()
+
+
+def _get_topic(client_topic, provider):
+    topic = client_topic
+    if '/' in provider:
+        parts = provider.split('/', 1)
+        provider = parts[0]
+        topic = ['/' + parts[1]]
+        LOGGER.info("Using provider-specific topic %s for %s",
+                    topic, provider)
+    return topic
 
 
 class MirrorRequestManager(RequestManager):

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -111,6 +111,16 @@ class MoveItMirror(MoveItBase):
 
         return listeners, noop
 
+    def run(self):
+        """Start the transfer chains."""
+        signal.signal(signal.SIGTERM, self.chains_stop)
+        signal.signal(signal.SIGHUP, self.signal_reload_cfg_file)
+        self.notifier.start()
+        self.running = True
+        while self.running:
+            time.sleep(1)
+            self.publisher.heartbeat(30)
+
 
 def noop(*args, **kwargs):
     """Do not do anything."""

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -96,7 +96,7 @@ class MoveItMirror(MoveItBase):
     def reload_cfg_file(self, filename):
         """Reload the config file."""
         reload_config(filename, self.chains, self.create_listener_notifier,
-                      MirrorRequestManager, publisher=self.publisher)
+                      MirrorRequestManager, publisher=self.publisher, disable_backlog=True)
 
     def signal_reload_cfg_file(self, *args):
         """Reload the config file when we get a signal."""

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -51,6 +51,10 @@ MSG_COLLECTION_TAR = Message('/topic', 'collection',
                              {'collection':
                               [{'dataset': [{'uid': 'file1.tar.bz2',
                                              'uri': '/tmp/file1.tar.bz2'}]}]})
+MSG_MIRROR = Message('/topic', 'file', {'fname': 'file1', 'uri':
+                                        'scp://user@host/tmp/bar/file1.txt', 'uid':
+                                        'file1.txt', 'destination': 'scp://targethost.domain/tmp/bar/',
+                                        'origin': 'sourcehost.domain:9201'})
 COMPRESSION_CONFIG = """
 [DEFAULT]
 providers = 127.0.0.1:40000
@@ -1418,3 +1422,12 @@ def test_chain_publisher_needs_restarting_port_modified(Listener, NoisyPublisher
     chain = Chain("foo", config.copy())
     config["publish_port"] = 12346
     assert chain.publisher_needs_restarting(config.copy()) is True
+
+
+def test_replace_mda_for_mirror():
+    """Test that replacing metadata items works properly for Trollmoves Mirror."""
+    from trollmoves.client import replace_mda
+
+    kwargs = {'uri': '/another/path/{filename}.txt'}
+    res = replace_mda(MSG_MIRROR, kwargs)
+    assert res.data['uri'] == kwargs['uri']


### PR DESCRIPTION
Refactoring effort to make Trollmoves Mirror to work with already refactored Trollmoves Client.

Also adds the `MoveItMirror.run()` method that has been absent since version 0.6.0. So last usable version with Mirror at the moment is 0.6.0.