### PR TITLE
Refactoring move it server/client and allow passing fsspec-base remote info

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U codecov pytest pytest-cov pytest-bdd pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors
+          pip install -U codecov pytest pytest-cov pytest-bdd pytest-reraise pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors
 
       - name: Install trollmoves
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U codecov pytest pytest-cov pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog
+          pip install -U codecov pytest pytest-cov pytest-bdd pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog
 
       - name: Install trollmoves
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U codecov pytest pytest-cov pytest-bdd pytest-reraise pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors fsspec
+          pip install -U codecov pytest pytest-cov pytest-bdd pytest-reraise pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors>=0.13.0 fsspec
 
       - name: Install trollmoves
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U codecov pytest pytest-cov pytest-bdd pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog
+          pip install -U codecov pytest pytest-cov pytest-bdd pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors
 
       - name: Install trollmoves
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U codecov pytest pytest-cov pytest-bdd pytest-reraise pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors
+          pip install -U codecov pytest pytest-cov pytest-bdd pytest-reraise pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors fsspec
 
       - name: Install trollmoves
         run: |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Required libraries:
 In addition, the required packages for the transfer protocol(s) to be used need to be
 installed. See the mover documentation below for more details.
 
+#### Running the server without a client
+In some situations, it might be difficult to use the server/client architecture,
+and thus there is a possibility to run the server in stand alone mode. To do
+this, the only thing to do is omit the `request_port` configuration item in the
+server configuration. From that point on, the server will send full uris in
+the messages it publishes, along with a json representation of a `fsspec`
+filesystem. From there, processes accepting these (eg `trollflow2`) will be able
+to use `fsspec` to read and process the remote files.
+
 ### Trollmoves Client
 
 Trollmoves Client is configured to subscribe to a specific topic, and to make requests

--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -76,49 +76,12 @@ with the -l or --log option::
 """
 
 # TODO: implement ping and server selection
-import logging
 import logging.handlers
-import argparse
-import signal
-import time
 
-from trollmoves.move_it_base import MoveItBase
+from trollmoves.client import parse_args, MoveItClient
 
 LOGGER = logging.getLogger("move_it_client")
 LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
-
-
-class MoveItClient(MoveItBase):
-    """Trollmoves client class."""
-
-    def __init__(self, cmd_args):
-        """Initialize client."""
-        super(MoveItClient, self).__init__(cmd_args, "client")
-
-    def run(self):
-        """Start the transfer chains."""
-        signal.signal(signal.SIGTERM, self.chains_stop)
-        signal.signal(signal.SIGHUP, self.signal_reload_cfg_file)
-        self.notifier.start()
-        self.running = True
-        while self.running:
-            time.sleep(1)
-            for chain_name in self.chains:
-                if not self.chains[chain_name].is_alive():
-                    self.chains[chain_name] = self.chains[chain_name].restart()
-                self.chains[chain_name].publisher.heartbeat(30)
-
-
-def parse_args():
-    """Parse commandline arguments."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("config_file",
-                        help="The configuration file to run on.")
-    parser.add_argument("-l", "--log",
-                        help="The file to log to. stdout otherwise.")
-    parser.add_argument("-v", "--verbose", default=False, action="store_true",
-                        help="Toggle verbose logging")
-    return parser.parse_args()
 
 
 def main():

--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -23,30 +23,11 @@
 """Move it Mirror."""
 
 import logging.handlers
-import argparse
 
-from trollmoves.mirror import MoveItMirror
+from trollmoves.mirror import MoveItMirror, parse_args
 
 LOGGER = logging.getLogger("move_it_mirror")
 LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
-
-
-def parse_args():
-    """Parse the command line arguments."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("config_file",
-                        help="The configuration file to run on.")
-    parser.add_argument("-l",
-                        "--log",
-                        help="The file to log to. stdout otherwise.")
-    parser.add_argument("-p",
-                        "--port",
-                        help="The port to publish on. 9010 is the default",
-                        default=9010)
-    parser.add_argument("-v", "--verbose", default=False, action="store_true",
-                        help="Toggle verbose logging")
-
-    return parser.parse_args()
 
 
 def main():

--- a/bin/move_it_server.py
+++ b/bin/move_it_server.py
@@ -92,34 +92,11 @@ ith the -l or --log option::
   move_it_server --log /path/to/mylogfile.log myconfig.ini
 """
 
-import logging
 import logging.handlers
-import argparse
-from trollmoves.server import MoveItServer
+from trollmoves.server import MoveItServer, parse_args
 
 LOGGER = logging.getLogger("move_it_server")
 LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
-
-
-def parse_args():
-    """Parse command-line arguments."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("config_file",
-                        help="The configuration file to run on.")
-    parser.add_argument("-l", "--log",
-                        help="The file to log to. stdout otherwise.")
-    parser.add_argument("-p", "--port",
-                        help="The port to publish on. 9010 is the default",
-                        default=9010)
-    parser.add_argument("-v", "--verbose", default=False, action="store_true",
-                        help="Toggle verbose logging")
-    parser.add_argument("--disable-backlog",
-                        help="Disable glob and handling of backlog of files at start/restart",
-                        action='store_true')
-    parser.add_argument("-w", "--watchdog", default=False, action="store_true",
-                        help="Use Watchdog instead of inotify")
-
-    return parser.parse_args()
 
 
 def main():
@@ -128,8 +105,7 @@ def main():
     server = MoveItServer(cmd_args)
 
     try:
-        server.reload_cfg_file(cmd_args.config_file,
-                               disable_backlog=cmd_args.disable_backlog)
+        server.reload_cfg_file(cmd_args.config_file)
         server.run()
     except KeyboardInterrupt:
         LOGGER.debug("Stopping Trollmoves server")

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,6 @@ setup(name="trollmoves",
                         'trollsift', 'netifaces',
                         'pyzmq', 'inotify',
                         'scp', 'paramiko', 'pyyaml', 'watchdog'],
+      tests_require=["pytest", "pytest-reraise", "pytest-bdd"],
+      extras_require={"remote_fs": ["pytroll-collectors"]},
       )

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extras_require = {
         'scp',
         'watchdog',
     ],
-    "remote_fs": ["pytroll-collectors"],
+    "remote_fs": ["pytroll-collectors>=0.13.0"],
 }
 
 all_extras = []

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -489,7 +489,7 @@ def make_uris(msg, destination, login=None):
 
 
 def replace_mda(msg, kwargs):
-    """Replace messate metadata with items in kwargs dict."""
+    """Replace message metadata with items in kwargs dict."""
     for key in msg.data:
         if key in kwargs:
             try:

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -25,7 +25,6 @@
 import argparse
 import logging
 import os
-import signal
 import socket
 import time
 from collections import deque
@@ -1014,18 +1013,11 @@ class MoveItClient(MoveItBase):
         reload_config(self.cmd_args.config_file, self.chains,
                       publisher=self.publisher)
 
-    def run(self):
-        """Start the transfer chains."""
-        signal.signal(signal.SIGTERM, self.chains_stop)
-        signal.signal(signal.SIGHUP, self.signal_reload_cfg_file)
-        self.notifier.start()
-        self.running = True
-        while self.running:
-            time.sleep(1)
-            for chain_name in self.chains:
-                if not self.chains[chain_name].is_alive():
-                    self.chains[chain_name] = self.chains[chain_name].restart()
-                self.chains[chain_name].publisher.heartbeat(30)
+    def _run(self):
+        for chain_name in self.chains:
+            if not self.chains[chain_name].is_alive():
+                self.chains[chain_name] = self.chains[chain_name].restart()
+            self.chains[chain_name].publisher.heartbeat(30)
 
     def terminate(self):
         """Terminate client chains."""

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -92,11 +92,11 @@ class MoveItMirror(AbstractMoveItServer):
         self.name = "move_it_mirror"
         publisher = create_publisher(cmd_args.port, self.name)
         super().__init__(cmd_args, publisher=publisher)
+        self.request_manager = MirrorRequestManager
 
     def reload_cfg_file(self, filename):
         """Reload the config file."""
-        self.reload_config(filename, self.create_listener_notifier,
-                           MirrorRequestManager, disable_backlog=True)
+        self.reload_config(filename, self.create_listener_notifier, disable_backlog=True)
 
     def signal_reload_cfg_file(self, *args):
         """Reload the config file when we get a signal."""

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -24,8 +24,6 @@
 import argparse
 import os
 import logging
-import signal
-import time
 
 from urllib.parse import urlparse, urlunparse
 from threading import Lock, Timer
@@ -110,16 +108,6 @@ class MoveItMirror(AbstractMoveItServer):
         listeners = Listeners(attrs.pop("client_topic"), attrs.pop("providers"), **attrs)
 
         return listeners, noop
-
-    def run(self):
-        """Start the transfer chains."""
-        signal.signal(signal.SIGTERM, self.chains_stop)
-        signal.signal(signal.SIGHUP, self.signal_reload_cfg_file)
-        self.notifier.start()
-        self.running = True
-        while self.running:
-            time.sleep(1)
-            self.publisher.heartbeat(30)
 
 
 def noop(*args, **kwargs):

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -21,7 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """All you need for mirroring."""
-
+import argparse
 import os
 import logging
 import signal
@@ -35,9 +35,8 @@ from posttroll.publisher import get_own_ip
 
 from trollmoves.client import Listener
 from trollmoves.client import request_push
-from trollmoves.server import RequestManager, Deleter
-from trollmoves.move_it_base import MoveItBase, create_publisher
-from trollmoves.server import reload_config
+from trollmoves.server import RequestManager, Deleter, AbstractMoveItServer
+from trollmoves.move_it_base import create_publisher
 
 
 LOGGER = logging.getLogger(__name__)
@@ -85,18 +84,19 @@ def publish_mirror_message(mirror_message, publisher_send):
     publisher_send(str(mirror_message))
 
 
-class MoveItMirror(MoveItBase):
+class MoveItMirror(AbstractMoveItServer):
     """Mirror for move_it."""
 
     def __init__(self, cmd_args):
         """Set up the mirror."""
-        publisher = create_publisher(cmd_args.port, "move_it_mirror")
-        super(MoveItMirror, self).__init__(cmd_args, "mirror", publisher=publisher)
+        self.name = "move_it_mirror"
+        publisher = create_publisher(cmd_args.port, self.name)
+        super().__init__(cmd_args, publisher=publisher)
 
     def reload_cfg_file(self, filename):
         """Reload the config file."""
-        reload_config(filename, self.chains, self.create_listener_notifier,
-                      MirrorRequestManager, publisher=self.publisher, disable_backlog=True)
+        self.reload_config(filename, self.create_listener_notifier,
+                           MirrorRequestManager, disable_backlog=True)
 
     def signal_reload_cfg_file(self, *args):
         """Reload the config file when we get a signal."""
@@ -204,3 +204,21 @@ class MirrorDeleter(Deleter):
         Deleter.delete(filename)
         # Pop is atomic, so we don't need a lock.
         file_registry.pop(os.path.basename(filename), None)
+
+
+def parse_args(args=None):
+    """Parse the command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config_file",
+                        help="The configuration file to run on.")
+    parser.add_argument("-l",
+                        "--log",
+                        help="The file to log to. stdout otherwise.")
+    parser.add_argument("-p",
+                        "--port",
+                        help="The port to publish on. 9010 is the default",
+                        default=9010)
+    parser.add_argument("-v", "--verbose", default=False, action="store_true",
+                        help="Toggle verbose logging")
+
+    return parser.parse_args(args)

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -68,7 +68,7 @@ class MoveItBase(ABC):
     @abstractmethod
     def terminate(self):
         """Terminate the chains and threads."""
-        pass
+        pass  # noqa
 
     def setup_watchers(self):
         """Set up watcher for the configuration file."""

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -49,7 +49,6 @@ class MoveItBase(ABC):
         self.notifier = None
         self.watchman = None
         self.publisher = publisher
-        self._np = None
         self.chains = {}
         self.setup_logging()
         LOGGER.info("Starting up.")
@@ -68,7 +67,7 @@ class MoveItBase(ABC):
         except RuntimeError as err:
             LOGGER.warning("Could not stop notifier: %s", err)
         with suppress(AttributeError):
-            self._np.stop()
+            self.publisher.stop()
         self.terminate()
 
     @abstractmethod

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -26,6 +26,8 @@
 import logging
 import logging.handlers
 import os
+from abc import ABC, abstractmethod
+from contextlib import suppress
 
 import pyinotify
 from posttroll.publisher import Publisher
@@ -34,65 +36,41 @@ LOGGER = logging.getLogger("move_it_base")
 LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
 
 
-class MoveItBase(object):
+class MoveItBase(ABC):
     """Base class for Trollmoves."""
 
-    def __init__(self, cmd_args, chain_type, publisher=None):
+    def __init__(self, cmd_args, publisher=None):
         """Initialize the class."""
         self.cmd_args = cmd_args
-        self.chain_type = chain_type
         self.running = False
         self.notifier = None
         self.watchman = None
         self.publisher = publisher
         self._np = None
         self.chains = {}
-        setup_logging(cmd_args, chain_type)
+        self.setup_logging()
         LOGGER.info("Starting up.")
-        self.setup_watchers(cmd_args)
-
-    def reload_cfg_file(self, filename, *args, **kwargs):
-        """Reload configuration file."""
-        if self.chain_type == "client":
-            from trollmoves.client import reload_config
-            reload_config(filename, self.chains, *args, **kwargs)
-        else:
-            # Also Mirror uses the reload_config from the Server
-            from trollmoves.server import reload_config
-            reload_config(filename, self.chains, *args, publisher=self.publisher,
-                          use_watchdog=self.cmd_args.watchdog,
-                          disable_backlog=self.cmd_args.disable_backlog)
-
-    def signal_reload_cfg_file(self, *args):
-        """Handle reload signal."""
-        del args
-        if self.chain_type == "client":
-            from trollmoves.client import reload_config
-            reload_config(self.cmd_args.config_file, self.chains,
-                          publisher=self.publisher)
-        else:
-            from trollmoves.server import reload_config
-            reload_config(self.cmd_args.config_file, self.chains,
-                          publisher=self.publisher,
-                          use_watchdog=self.cmd_args.watchdog,
-                          disable_backlog=self.cmd_args.disable_backlog)
+        self.setup_watchers()
+        self.name = "move_it_base"
 
     def chains_stop(self, *args):
         """Stop all transfer chains."""
         del args
-        if self.chain_type == "client":
-            from trollmoves.client import terminate
-        else:
-            from trollmoves.server import terminate
         self.running = False
-        self.notifier.stop()
         try:
+            self.notifier.stop()
+        except RuntimeError as err:
+            LOGGER.warning("Could not stop notifier: %s", err)
+        with suppress(AttributeError):
             self._np.stop()
-        except AttributeError:
-            pass
-        terminate(self.chains)
+        self.terminate()
 
-    def setup_watchers(self, cmd_args):
+    @abstractmethod
+    def terminate(self):
+        """Terminate the chains and threads."""
+        pass
+
+    def setup_watchers(self):
         """Set up watcher for the configuration file."""
         mask = (pyinotify.IN_CLOSE_WRITE |
                 pyinotify.IN_MOVED_TO |
@@ -104,35 +82,29 @@ class MoveItBase(object):
                                      tmask=mask,
                                      cmd_filename=self.cmd_args.config_file)
         self.notifier = pyinotify.ThreadedNotifier(self.watchman, event_handler)
-        self.watchman.add_watch(os.path.dirname(cmd_args.config_file), mask)
+        self.watchman.add_watch(os.path.dirname(self.cmd_args.config_file), mask)
 
+    def setup_logging(self):
+        """Set up logging."""
+        global LOGGER
+        LOGGER = logging.getLogger('')
+        if self.cmd_args.verbose:
+            LOGGER.setLevel(logging.DEBUG)
 
-def setup_logging(cmd_args, chain_type):
-    """Set up logging."""
-    global LOGGER
-    LOGGER = logging.getLogger('')
-    if cmd_args.verbose:
-        LOGGER.setLevel(logging.DEBUG)
+        if self.cmd_args.log:
+            fh_ = logging.handlers.TimedRotatingFileHandler(
+                os.path.join(self.cmd_args.log),
+                "midnight",
+                backupCount=7)
+        else:
+            fh_ = logging.StreamHandler()
 
-    if cmd_args.log:
-        fh_ = logging.handlers.TimedRotatingFileHandler(
-            os.path.join(cmd_args.log),
-            "midnight",
-            backupCount=7)
-    else:
-        fh_ = logging.StreamHandler()
+        formatter = logging.Formatter(LOG_FORMAT)
+        fh_.setFormatter(formatter)
 
-    formatter = logging.Formatter(LOG_FORMAT)
-    fh_.setFormatter(formatter)
-
-    LOGGER.addHandler(fh_)
-    logger_name = "move_it_server"
-    if chain_type == "client":
-        logger_name = "move_it_client"
-    elif chain_type == "mirror":
-        logger_name = "move_it_mirror"
-    LOGGER = logging.getLogger(logger_name)
-    pyinotify.log.handlers = [fh_]
+        LOGGER.addHandler(fh_)
+        LOGGER = logging.getLogger(self.name)
+        pyinotify.log.handlers = [fh_]
 
 
 def create_publisher(port, publisher_name):

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -68,7 +68,6 @@ class MoveItBase(ABC):
     @abstractmethod
     def terminate(self):
         """Terminate the chains and threads."""
-        pass  # noqa
 
     def setup_watchers(self):
         """Set up watcher for the configuration file."""

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -346,16 +346,6 @@ class MoveItServer(AbstractMoveItServer):
         self.reload_cfg_file(self.cmd_args.config_file)
 
 
-class MoveItServerWithoutRequester(MoveItServer):
-    """Wrapper class for Trollmoves Server."""
-
-    def __init__(self, cmd_args):
-        """Initialize server."""
-        self.name = "move_it_server_no_request"
-        super().__init__(cmd_args)
-        self.request_manager = None
-
-
 class ConfigError(Exception):
     """Configuration error."""
 
@@ -665,10 +655,11 @@ class Chain:
         self.config = config.copy()
         self.request_manager = None
         self.notifier = None
+        self.needs_manager = "request_port" in self.config
 
     def create_manager(self, manager):
         """Create a request manager."""
-        if manager is None:
+        if manager is None or not self.needs_manager:
             return
         try:
             self.request_manager = manager(int(self.config["request_port"]), self.config)

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -796,11 +796,8 @@ def create_message_with_request_info(pathname, orig_pathname, attrs):
 
 def create_message_with_remote_fs_info(pathname, attrs):
     """Create a message containing remote filesystem info."""
-    from pytroll_collectors.fsspec_to_message import extract_files_to_message
-    import fsspec
-    import socket
-    fs = fsspec.filesystem('ssh', host=socket.gethostname())
-    msg = extract_files_to_message(pathname, fs, attrs['topic'], attrs.get("unpack"))
+    from pytroll_collectors.fsspec_to_message import extract_local_files_to_message_for_remote_use
+    msg = extract_local_files_to_message_for_remote_use(pathname, attrs['topic'], attrs.get("unpack"))
     info = _collect_attribute_info(attrs)
     msg.data.update(info)
     return msg

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -742,7 +742,7 @@ def process_notify(orig_pathname, publisher, pattern, attrs):
     if "request_port" in attrs:
         msg = create_message_with_request_info(pathname, orig_pathname, attrs)
     else:
-        msg = create_message_with_remote_fs_info(pathname, attrs)
+        msg = create_message_with_remote_fs_info(pathname, orig_pathname, attrs)
     publisher.send(str(msg))
     LOGGER.debug("Message sent: %s", str(msg))
 
@@ -756,11 +756,12 @@ def create_message_with_request_info(pathname, orig_pathname, attrs):
     return msg
 
 
-def create_message_with_remote_fs_info(pathname, attrs):
+def create_message_with_remote_fs_info(pathname, orig_pathname, attrs):
     """Create a message containing remote filesystem info."""
     from pytroll_collectors.fsspec_to_message import extract_local_files_to_message_for_remote_use
     msg = extract_local_files_to_message_for_remote_use(pathname, attrs['topic'], attrs.get("unpack"))
     info = _collect_attribute_info(attrs)
+    info.update(parse(attrs["origin"], orig_pathname))
     msg.data.update(info)
     return msg
 

--- a/trollmoves/tests/functional/move_it_server_client.feature
+++ b/trollmoves/tests/functional/move_it_server_client.feature
@@ -1,0 +1,12 @@
+Feature: Move it server and client
+    Move it server and client interaction.
+
+    Scenario: Simple file transfer
+        Given We have a source directory
+        And We have a separate destination directory
+        And Move it server is started
+        And Move it client is started
+
+        When A new file arrives matching the pattern
+
+        Then The file should be moved to the destination directory

--- a/trollmoves/tests/functional/move_it_server_client.feature
+++ b/trollmoves/tests/functional/move_it_server_client.feature
@@ -10,3 +10,21 @@ Feature: Move it server and client
         When A new file arrives matching the pattern
 
         Then The file should be moved to the destination directory
+
+    Scenario: Simple file publishing
+        Given We have a source directory
+        And A posttroll subscriber is started
+        And Move it server with no request port is started
+
+        When A new file arrives matching the pattern
+
+        Then A posttroll message with filesystem information should be issued by the server
+
+    Scenario: Simple file publishing with untarring
+        Given We have a source directory
+        And A posttroll subscriber is started
+        And Move it server with no request port is started with untarring option activated
+
+        When A new tar file arrives matching the pattern
+
+        Then A posttroll message with filesystem information and untarred file collection should be issued by the server

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -207,6 +207,7 @@ def check_message_for_filesystem_info(subscriber, tmp_path, source_dir, moved_fi
     assert msg.data["uri"] == expected_uri
     assert msg.data["sensor"] == "seviri"
     assert msg.data["variant"] == "0DEG"
+    assert "nominal_time" in msg.data
 
 
 @scenario('move_it_server_client.feature', 'Simple file publishing with untarring')

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -66,7 +66,7 @@ def create_target_directory(tmp_path):
 
 
 @pytest.fixture
-def server(source_dir, tmp_path):
+def server(source_dir, tmp_path, reraise):
     """Create a move it server instance."""
     server_config = f"""
     [eumetcast-hrit-0deg]
@@ -84,7 +84,7 @@ def server(source_dir, tmp_path):
                                   str(server_config_filename)])
     server = MoveItServer(cmd_args)
     server.reload_cfg_file(cmd_args.config_file)
-    thread = Thread(target=server.run)
+    thread = Thread(target=reraise.wrap(server.run))
     thread.start()
     yield server
     server.chains_stop()
@@ -98,7 +98,7 @@ def start_move_it_server(server):
 
 
 @pytest.fixture
-def client(target_dir, tmp_path):
+def client(target_dir, tmp_path, reraise):
     """Create a move it client."""
     client_config = f"""
     [eumetcast_hrit_0deg_ftp]
@@ -114,7 +114,7 @@ def client(target_dir, tmp_path):
     cmd_args = parse_args_client(["-v", "-l", str(tmp_path / "move_it_client.log"), str(client_config_filename)])
     client = MoveItClient(cmd_args)
     client.reload_cfg_file(cmd_args.config_file)
-    thread = Thread(target=client.run)
+    thread = Thread(target=reraise.wrap(client.run))
     thread.start()
     yield client
     client.chains_stop()
@@ -151,7 +151,7 @@ def test_simple_publishing():
 
 
 @pytest.fixture
-def server_without_request_port(source_dir, tmp_path, free_port):
+def server_without_request_port(source_dir, tmp_path, free_port, reraise):
     """Create a move it server instance."""
     server_config = f"""
     [eumetcast-hrit-0deg]
@@ -167,7 +167,7 @@ def server_without_request_port(source_dir, tmp_path, free_port):
                                   str(server_config_filename)])
     server = MoveItServerWithoutRequester(cmd_args)
     server.reload_cfg_file(cmd_args.config_file)
-    thread = Thread(target=server.run)
+    thread = Thread(target=reraise.wrap(server.run))
     thread.start()
     yield server
     server.chains_stop()
@@ -215,7 +215,7 @@ def test_simple_publishing_with_untarring():
 
 
 @pytest.fixture
-def server_without_request_port_and_untarring(source_dir, tmp_path, free_port):
+def server_without_request_port_and_untarring(source_dir, tmp_path, free_port, reraise):
     """Create a move it server instance."""
     server_config = f"""
     [eumetcast-hrit-0deg]
@@ -232,7 +232,7 @@ def server_without_request_port_and_untarring(source_dir, tmp_path, free_port):
                                   str(server_config_filename)])
     server = MoveItServerWithoutRequester(cmd_args)
     server.reload_cfg_file(cmd_args.config_file)
-    thread = Thread(target=server.run)
+    thread = Thread(target=reraise.wrap(server.run))
     thread.start()
     yield server
     server.chains_stop()

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -17,7 +17,6 @@ import os
 @scenario('move_it_server_client.feature', 'Simple file transfer')
 def test_simple_transfer():
     """Stub for this scenario."""
-    pass  # noqa
 
 
 @given("We have a source directory", target_fixture="source_dir")

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -17,7 +17,7 @@ import os
 @scenario('move_it_server_client.feature', 'Simple file transfer')
 def test_simple_transfer():
     """Stub for this scenario."""
-    pass
+    pass  # noqa
 
 
 @given("We have a source directory", target_fixture="source_dir")

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -2,16 +2,46 @@
 
 from pytest_bdd import scenario, given, when, then
 import pytest
-from trollmoves.server import MoveItServer
+from trollmoves.server import MoveItServer, MoveItServerWithoutRequester
 from trollmoves.server import parse_args as parse_args_server
 from trollmoves.client import MoveItClient
 from trollmoves.client import parse_args as parse_args_client
 from pathlib import Path
 from datetime import datetime
 import time
+import socket
 from threading import Thread
+from posttroll.subscriber import Subscriber
 
 import os
+
+
+@pytest.fixture
+def free_port():
+    """Get a free port.
+
+    From https://gist.github.com/bertjwregeer/0be94ced48383a42e70c3d9fff1f4ad0
+
+    Returns a factory that finds the next free port that is available on the OS
+    This is a bit of a hack, it does this by creating a new socket, and calling
+    bind with the 0 port. The operating system will assign a brand new port,
+    which we can find out using getsockname(). Once we have the new port
+    information we close the socket thereby returning it to the free pool.
+    This means it is technically possible for this function to return the same
+    port twice (for example if run in very quick succession), however operating
+    systems return a random port number in the default range (1024 - 65535),
+    and it is highly unlikely for two processes to get the same port number.
+    In other words, it is possible to flake, but incredibly unlikely.
+    """
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", 0))
+    portnum = s.getsockname()[1]
+    s.close()
+
+    return portnum
 
 
 @scenario('move_it_server_client.feature', 'Simple file transfer')
@@ -113,3 +143,136 @@ def file_moved(target_dir, moved_filename):
     path = Path(target_dir / moved_filename)
     time.sleep(1)
     assert path.exists()
+
+
+@scenario('move_it_server_client.feature', 'Simple file publishing')
+def test_simple_publishing():
+    """Stub for this scenario."""
+
+
+@pytest.fixture
+def server_without_request_port(source_dir, tmp_path, free_port):
+    """Create a move it server instance."""
+    server_config = f"""
+    [eumetcast-hrit-0deg]
+    origin = {str(source_dir)}/H-000-{{nominal_time:%Y%m%d%H%M}}-__
+    info = sensor=seviri;variant=0DEG
+    topic = /1b/hrit-segment/0deg
+    delete = False
+    """
+    server_config_filename = tmp_path / "server_config.cfg"
+    with open(server_config_filename, "wb") as fp:
+        fp.write(server_config.encode())
+    cmd_args = parse_args_server(["--port", str(free_port), "-v", "-l", str(tmp_path / "move_it_server.log"),
+                                  str(server_config_filename)])
+    server = MoveItServerWithoutRequester(cmd_args)
+    server.reload_cfg_file(cmd_args.config_file)
+    thread = Thread(target=server.run)
+    thread.start()
+    yield server
+    server.chains_stop()
+    thread.join()
+
+
+@given("Move it server with no request port is started")
+def start_move_it_server_without_request_port(server_without_request_port):
+    """Start a move_it_server instance without a request port."""
+    return server_without_request_port
+
+
+@pytest.fixture
+def subscriber(free_port):
+    """Create a subscriber."""
+    sub = Subscriber([f"tcp://localhost:{free_port}"], "")
+    yield sub(timeout=2)
+    sub.close()
+
+
+@given("A posttroll subscriber is started")
+def start_subscriber(subscriber):
+    """Start a subscriber."""
+    return subscriber
+
+
+@then("A posttroll message with filesystem information should be issued by the server")
+def check_message_for_filesystem_info(subscriber, tmp_path, source_dir, moved_filename):
+    """Check the posttroll message for filesystem info."""
+    msg = next(subscriber)
+    expected_filesystem = {"cls": "fsspec.implementations.sftp.SFTPFileSystem", "protocol": "sftp", "args": [],
+                           "host": socket.gethostname()}
+    expected_uid = f'sftp://{source_dir}/{moved_filename}'
+
+    assert msg.data["filesystem"] == expected_filesystem
+    assert msg.data["uid"] == expected_uid
+    assert msg.data["sensor"] == "seviri"
+    assert msg.data["variant"] == "0DEG"
+
+
+@scenario('move_it_server_client.feature', 'Simple file publishing with untarring')
+def test_simple_publishing_with_untarring():
+    """Stub for this scenario."""
+
+
+@pytest.fixture
+def server_without_request_port_and_untarring(source_dir, tmp_path, free_port):
+    """Create a move it server instance."""
+    server_config = f"""
+    [eumetcast-hrit-0deg]
+    origin = {source_dir}/H-000-{{nominal_time:%Y%m%d%H%M}}-__.tar
+    info = sensor=seviri;variant=0DEG
+    topic = /1b/hrit-segment/0deg
+    delete = False
+    unpack = tar
+    """
+    server_config_filename = tmp_path / "server_config.cfg"
+    with open(server_config_filename, "wb") as fp:
+        fp.write(server_config.encode())
+    cmd_args = parse_args_server(["--port", str(free_port), "-v", "-l", str(tmp_path / "move_it_server.log"),
+                                  str(server_config_filename)])
+    server = MoveItServerWithoutRequester(cmd_args)
+    server.reload_cfg_file(cmd_args.config_file)
+    thread = Thread(target=server.run)
+    thread.start()
+    yield server
+    server.chains_stop()
+    thread.join()
+
+
+@given("Move it server with no request port is started with untarring option activated")
+def start_move_it_server_with_untarring(server_without_request_port_and_untarring):
+    """Start a move_it_server instance without a request port."""
+    return server_without_request_port
+
+
+@when("A new tar file arrives matching the pattern", target_fixture="moved_filename")
+def create_new_tar_file(source_dir):
+    """Create a new file in source_dir."""
+    pattern = "H-000-%Y%m%d%H%M-__"
+    filename = datetime.utcnow().strftime(pattern)
+    path = source_dir / filename
+    path.write_bytes(b"Very Important Satellite Data")
+    tarfilename = source_dir / (filename + ".tar")
+    from tarfile import TarFile
+    with TarFile(tarfilename, mode="w") as tarfile:
+        tarfile.add(path)
+    return tarfilename
+
+
+@then("A posttroll message with filesystem information and untarred file collection should be issued by the server")
+def check_message_for_filesystem_info_and_untarring(subscriber, tmp_path, moved_filename):
+    """Check the posttroll message for filesystem info and untarring."""
+    msg = next(subscriber)
+    expected_filesystem = {"cls": "fsspec.implementations.tar.TarFileSystem",
+                           "protocol": "tar",
+                           "args": [],
+                           "target_options": {"host": socket.gethostname(), "protocol": "sftp"},
+                           "target_protocol": "sftp",
+                           "fo": os.fspath(moved_filename)}
+
+    expected_uid = f'tar:/{str(moved_filename)[:-4]}::sftp://{moved_filename}'
+
+    assert len(msg.data["dataset"]) == 1
+    assert msg.data["dataset"][0]["filesystem"] == expected_filesystem
+    assert msg.data["dataset"][0]["uid"] == expected_uid
+    assert msg.data["sensor"] == "seviri"
+    assert msg.data["variant"] == "0DEG"

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -2,7 +2,7 @@
 
 from pytest_bdd import scenario, given, when, then
 import pytest
-from trollmoves.server import MoveItServer, MoveItServerWithoutRequester
+from trollmoves.server import MoveItServer
 from trollmoves.server import parse_args as parse_args_server
 from trollmoves.client import MoveItClient
 from trollmoves.client import parse_args as parse_args_client
@@ -165,7 +165,7 @@ def server_without_request_port(source_dir, tmp_path, free_port, reraise):
         fp.write(server_config.encode())
     cmd_args = parse_args_server(["--port", str(free_port), "-v", "-l", str(tmp_path / "move_it_server.log"),
                                   str(server_config_filename)])
-    server = MoveItServerWithoutRequester(cmd_args)
+    server = MoveItServer(cmd_args)
     server.reload_cfg_file(cmd_args.config_file)
     thread = Thread(target=reraise.wrap(server.run))
     thread.start()
@@ -230,7 +230,7 @@ def server_without_request_port_and_untarring(source_dir, tmp_path, free_port, r
         fp.write(server_config.encode())
     cmd_args = parse_args_server(["--port", str(free_port), "-v", "-l", str(tmp_path / "move_it_server.log"),
                                   str(server_config_filename)])
-    server = MoveItServerWithoutRequester(cmd_args)
+    server = MoveItServer(cmd_args)
     server.reload_cfg_file(cmd_args.config_file)
     thread = Thread(target=reraise.wrap(server.run))
     thread.start()

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -1,0 +1,116 @@
+"""Acceptance tests for move it server/client."""
+
+from pytest_bdd import scenario, given, when, then
+import pytest
+from trollmoves.server import MoveItServer
+from trollmoves.server import parse_args as parse_args_server
+from trollmoves.client import MoveItClient
+from trollmoves.client import parse_args as parse_args_client
+from pathlib import Path
+from datetime import datetime
+import time
+from threading import Thread
+
+import os
+
+
+@scenario('move_it_server_client.feature', 'Simple file transfer')
+def test_simple_transfer():
+    """Stub for this scenario."""
+    pass
+
+
+@given("We have a source directory", target_fixture="source_dir")
+def create_source_directory(tmp_path):
+    """Create a source directory."""
+    dirname = tmp_path / "source"
+    os.mkdir(dirname)
+    return dirname
+
+
+@given("We have a separate destination directory", target_fixture="target_dir")
+def create_target_directory(tmp_path):
+    """Create a target directory."""
+    dirname = tmp_path / "target"
+    os.mkdir(dirname)
+    return dirname
+
+
+@pytest.fixture
+def server(source_dir, tmp_path):
+    """Create a move it server instance."""
+    server_config = f"""
+    [eumetcast-hrit-0deg]
+    origin = {str(source_dir)}/H-000-{{nominal_time:%Y%m%d%H%M}}-__
+    request_port = 9094
+    publisher_port = 9010
+    info = sensor=seviri;variant=0DEG
+    topic = /1b/hrit-segment/0deg
+    delete = False
+    """
+    server_config_filename = tmp_path / "server_config.cfg"
+    with open(server_config_filename, "wb") as fp:
+        fp.write(server_config.encode())
+    cmd_args = parse_args_server(["--port", "9010", "-v", "-l", str(tmp_path / "move_it_server.log"),
+                                  str(server_config_filename)])
+    server = MoveItServer(cmd_args)
+    server.reload_cfg_file(cmd_args.config_file)
+    thread = Thread(target=server.run)
+    thread.start()
+    yield server
+    server.chains_stop()
+    thread.join()
+
+
+@given("Move it server is started")
+def start_move_it_server(server):
+    """Start a move_it_server instance."""
+    return server
+
+
+@pytest.fixture
+def client(target_dir, tmp_path):
+    """Create a move it client."""
+    client_config = f"""
+    [eumetcast_hrit_0deg_ftp]
+    providers = localhost:9010
+    destination = file://{str(target_dir)}
+    topic = /1b/hrit-segment/0deg
+    publish_port = 0
+    heartbeat_alarm_scale = 10
+    """
+    client_config_filename = tmp_path / "client_config.cfg"
+    with open(client_config_filename, "wb") as fp:
+        fp.write(client_config.encode())
+    cmd_args = parse_args_client(["-v", "-l", str(tmp_path / "move_it_client.log"), str(client_config_filename)])
+    client = MoveItClient(cmd_args)
+    client.reload_cfg_file(cmd_args.config_file)
+    thread = Thread(target=client.run)
+    thread.start()
+    yield client
+    client.chains_stop()
+    thread.join()
+
+
+@given("Move it client is started")
+def start_move_it_client(client):
+    """Start a move_it_client instance."""
+    return client
+
+
+@when("A new file arrives matching the pattern", target_fixture="moved_filename")
+def create_new_file(source_dir):
+    """Create a new file in source_dir."""
+    pattern = "H-000-%Y%m%d%H%M-__"
+    filename = datetime.utcnow().strftime(pattern)
+    path = Path(source_dir / filename)
+    path.write_bytes(b"Very Important Satellite Data")
+    return filename
+
+
+@then("The file should be moved to the destination directory")
+def file_moved(target_dir, moved_filename):
+    """Check that files is moved."""
+    path = Path(target_dir / moved_filename)
+    time.sleep(1)
+    assert path.exists()

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -66,13 +66,13 @@ def create_target_directory(tmp_path):
 
 
 @pytest.fixture
-def server(source_dir, tmp_path, reraise):
+def server(source_dir, tmp_path, free_port, reraise):
     """Create a move it server instance."""
     server_config = f"""
     [eumetcast-hrit-0deg]
     origin = {str(source_dir)}/H-000-{{nominal_time:%Y%m%d%H%M}}-__
     request_port = 9094
-    publisher_port = 9010
+    publisher_port = {free_port}
     info = sensor=seviri;variant=0DEG
     topic = /1b/hrit-segment/0deg
     delete = False
@@ -80,7 +80,7 @@ def server(source_dir, tmp_path, reraise):
     server_config_filename = tmp_path / "server_config.cfg"
     with open(server_config_filename, "wb") as fp:
         fp.write(server_config.encode())
-    cmd_args = parse_args_server(["--port", "9010", "-v", "-l", str(tmp_path / "move_it_server.log"),
+    cmd_args = parse_args_server(["--port", str(free_port), "-v", "-l", str(tmp_path / "move_it_server.log"),
                                   str(server_config_filename)])
     server = MoveItServer(cmd_args)
     server.reload_cfg_file(cmd_args.config_file)
@@ -98,11 +98,11 @@ def start_move_it_server(server):
 
 
 @pytest.fixture
-def client(target_dir, tmp_path, reraise):
+def client(target_dir, tmp_path, free_port, reraise):
     """Create a move it client."""
     client_config = f"""
     [eumetcast_hrit_0deg_ftp]
-    providers = localhost:9010
+    providers = localhost:{str(free_port)}
     destination = file://{str(target_dir)}
     topic = /1b/hrit-segment/0deg
     publish_port = 0

--- a/trollmoves/tests/functional/test_move_it_server_client.py
+++ b/trollmoves/tests/functional/test_move_it_server_client.py
@@ -207,7 +207,6 @@ def check_message_for_filesystem_info(subscriber, tmp_path, source_dir, moved_fi
     assert msg.data["uri"] == expected_uri
     assert msg.data["sensor"] == "seviri"
     assert msg.data["variant"] == "0DEG"
-    print(msg)
 
 
 @scenario('move_it_server_client.feature', 'Simple file publishing with untarring')
@@ -279,4 +278,3 @@ def check_message_for_filesystem_info_and_untarring(subscriber, tmp_path, moved_
     assert msg.data["dataset"][0]["uri"] == expected_uri
     assert msg.data["sensor"] == "seviri"
     assert msg.data["variant"] == "0DEG"
-    print(msg)

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -967,7 +967,7 @@ def test_read_config(client_config_1_item):
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_single_chain(Listener, NoisyPublisher, request_push, client_config_1_item):
+def test_reload_config_single_chain(Listener, create_publisher_from_dict_config, request_push, client_config_1_item):
     """Test trollmoves.client.reload_config() with a single chain."""
     from trollmoves.client import reload_config
 
@@ -977,7 +977,7 @@ def test_reload_config_single_chain(Listener, NoisyPublisher, request_push, clie
         reload_config(client_config_1_item, chains)
         assert len(chains) == 1
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
-        assert NoisyPublisher.call_count == 1
+        assert create_publisher_from_dict_config.call_count == 1
         assert Listener.call_count == 4
     finally:
         _stop_chains(chains)
@@ -987,7 +987,8 @@ def test_reload_config_single_chain(Listener, NoisyPublisher, request_push, clie
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, client_config_1_item, client_config_2_items):
+def test_reload_config_chain_added(Listener, create_publisher_from_dict_config, request_push,
+                                   client_config_1_item, client_config_2_items):
     """Test trollmoves.client.reload_config() when a chain is added."""
     from trollmoves.client import reload_config
 
@@ -999,7 +1000,7 @@ def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, clien
         assert len(chains) == 2
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
         assert "foo" in chains
-        assert NoisyPublisher.call_count == 2
+        assert create_publisher_from_dict_config.call_count == 2
         assert Listener.call_count == 5
     finally:
         _stop_chains(chains)
@@ -1010,7 +1011,7 @@ def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, clien
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_chain_removed(Listener, NoisyPublisher, request_push,
+def test_reload_config_chain_removed(Listener, create_publisher_from_dict_config, request_push,
                                      client_config_1_item, client_config_2_items):
     """Test trollmoves.client.reload_config() when a chain is added."""
     from trollmoves.client import reload_config
@@ -1023,7 +1024,7 @@ def test_reload_config_chain_removed(Listener, NoisyPublisher, request_push,
         assert len(chains) == 1
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
         assert "foo" not in chains
-        assert NoisyPublisher.call_count == 2
+        assert create_publisher_from_dict_config.call_count == 2
         assert Listener.call_count == 5
     finally:
         _stop_chains(chains)
@@ -1042,7 +1043,8 @@ def _stop_chains(chains):
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_publisher_items_not_changed(Listener, create_publisher_from_dict_config, request_push,
+                                                   client_config_1_item,
                                                    client_config_1_item_non_pub_provider_item_modified):
     """Test trollmoves.client.reload_config() when other than publisher related items are changed."""
     from trollmoves.client import reload_config
@@ -1051,9 +1053,9 @@ def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, req
 
     try:
         reload_config(client_config_1_item, chains)
-        NoisyPublisher.assert_called_once()
+        create_publisher_from_dict_config.assert_called_once()
         reload_config(client_config_1_item_non_pub_provider_item_modified, chains)
-        NoisyPublisher.assert_called_once()
+        create_publisher_from_dict_config.assert_called_once()
     finally:
         _stop_chains(chains)
         os.remove(client_config_1_item)
@@ -1063,8 +1065,8 @@ def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, req
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
-                                               client_config_1_pub_item_modified):
+def test_reload_config_publisher_items_changed(Listener, create_publisher_from_dict_config, request_push,
+                                               client_config_1_item, client_config_1_pub_item_modified):
     """Test trollmoves.client.reload_config() when publisher related items are changed."""
     from trollmoves.client import reload_config
 
@@ -1072,9 +1074,9 @@ def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, request
 
     try:
         reload_config(client_config_1_item, chains)
-        NoisyPublisher.assert_called_once()
+        create_publisher_from_dict_config.assert_called_once()
         reload_config(client_config_1_pub_item_modified, chains)
-        assert NoisyPublisher.call_count == 2
+        assert create_publisher_from_dict_config.call_count == 2
     finally:
         _stop_chains(chains)
         os.remove(client_config_1_item)
@@ -1084,8 +1086,8 @@ def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, request
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_not_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
-                                             client_config_1_item_non_pub_provider_item_modified):
+def test_reload_config_providers_not_changed(Listener, create_publisher_from_dict_config, request_push,
+                                             client_config_1_item, client_config_1_item_non_pub_provider_item_modified):
     """Test trollmoves.client.reload_config() when other than provider related options are changed."""
     from trollmoves.client import reload_config
 
@@ -1106,7 +1108,7 @@ def test_reload_config_providers_not_changed(Listener, NoisyPublisher, request_p
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_added(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_providers_added(Listener, create_publisher_from_dict_config, request_push, client_config_1_item,
                                        client_config_1_item_two_providers):
     """Test trollmoves.client.reload_config() when providers are added."""
     from trollmoves.client import reload_config
@@ -1136,8 +1138,8 @@ def _check_providers_listeners_and_listener_calls(chains, Listener, call_count=N
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_removed(Listener, NoisyPublisher, request_push, client_config_1_item,
-                                         client_config_1_item_two_providers):
+def test_reload_config_providers_removed(Listener, create_publisher_from_dict_config, request_push,
+                                         client_config_1_item, client_config_1_item_two_providers):
     """Test trollmoves.client.reload_config() when providers are removed."""
     from trollmoves.client import reload_config
 
@@ -1162,8 +1164,8 @@ def test_reload_config_providers_removed(Listener, NoisyPublisher, request_push,
 @patch('trollmoves.client.request_push')
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_provider_topic_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
-                                              client_config_1_item_topic_changed):
+def test_reload_config_provider_topic_changed(Listener, create_publisher_from_dict_config, request_push,
+                                              client_config_1_item, client_config_1_item_topic_changed):
     """Test trollmoves.client.reload_config() when the message topic is changed."""
     from trollmoves.client import reload_config
 
@@ -1461,7 +1463,7 @@ def test_chain_publisher_needs_restarting_nameservers_modified(Listener, create_
 
 @patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_publisher_needs_restarting_port_modified(Listener, NoisyPublisher):
+def test_chain_publisher_needs_restarting_port_modified(Listener, create_publisher_from_dict_config):
     """Test the publisher_needs_restarting() method of Chain object when publish port is modified."""
     from trollmoves.client import Chain
 

--- a/trollmoves/tests/test_mirror.py
+++ b/trollmoves/tests/test_mirror.py
@@ -24,6 +24,9 @@
 
 import unittest
 from unittest.mock import patch, DEFAULT
+from trollmoves.mirror import parse_args, MoveItMirror
+from tempfile import NamedTemporaryFile
+import pytest
 
 
 class TestMirrorDeleter(unittest.TestCase):
@@ -53,3 +56,59 @@ class TestMirrorRequestManager(unittest.TestCase):
             with patch.multiple("trollmoves.server", Poller=DEFAULT, get_context=DEFAULT):
                 MirrorRequestManager("some_port", attrs)  # noqa
                 assert md.call_args[0][0] == attrs
+
+
+config_file = b"""
+[eumetcast-hrit-0deg]
+origin = /local_disk/tellicast/received/MSGHRIT/H-000-{nominal_time:%Y%m%d%H%M}-{compressed:_<2s}
+request_port = 9094
+publisher_port = 9010
+info = sensor=seviri;variant=0DEG
+topic = /1b/hrit-segment/0deg
+delete = False
+"""
+
+
+class TestMoveItMirror:
+    """Test the move it mirror."""
+
+    def test_reloads_config_crashes_when_config_file_does_not_exist(self):
+        """Test that reloading a non existing config file crashes."""
+        cmd_args = parse_args(["--port", "9999", "somefile99999.cfg"])
+        mirror = MoveItMirror(cmd_args)
+        with pytest.raises(FileNotFoundError):
+            mirror.reload_cfg_file(cmd_args.config_file)
+
+    @patch("trollmoves.move_it_base.Publisher")
+    def test_reloads_config_on_example_config(self, fake_publisher):
+        """Test that config can be reloaded with basic example."""
+        with NamedTemporaryFile() as temporary_config_file:
+            temporary_config_file.write(config_file)
+            config_filename = temporary_config_file.name
+            cmd_args = parse_args(["--port", "9999", config_filename])
+            mirror = MoveItMirror(cmd_args)
+            mirror.reload_cfg_file(cmd_args.config_file)
+
+    @patch("trollmoves.move_it_base.Publisher")
+    @patch("trollmoves.mirror.MoveItMirror.reload_config")
+    def test_reloads_config_calls_reload_config(self, mock_reload_config, mock_publisher):
+        """Test that config file can be reloaded."""
+        with NamedTemporaryFile() as temporary_config_file:
+            temporary_config_file.write(config_file)
+            config_filename = temporary_config_file.name
+            cmd_args = parse_args(["--port", "9999", config_filename])
+            mirror = MoveItMirror(cmd_args)
+            mirror.reload_cfg_file(cmd_args.config_file)
+            mock_reload_config.assert_called_once()
+
+    @patch("trollmoves.move_it_base.Publisher")
+    @patch("trollmoves.mirror.MoveItMirror.reload_config")
+    def test_signal_reloads_config_calls_reload_config(self, mock_reload_config, mock_publisher):
+        """Test that config file can be reloaded through signal."""
+        with NamedTemporaryFile() as temporary_config_file:
+            temporary_config_file.write(config_file)
+            config_filename = temporary_config_file.name
+            cmd_args = parse_args([config_filename])
+            client = MoveItMirror(cmd_args)
+            client.signal_reload_cfg_file()
+            mock_reload_config.assert_called_once()

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -24,13 +24,15 @@
 
 from unittest.mock import MagicMock, patch
 import unittest
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 import os
 from collections import deque
 import time
 import datetime as dt
+import pytest
 
 from trollsift import globify
+from trollmoves.server import MoveItServer, parse_args
 
 
 @patch("trollmoves.server.process_notify")
@@ -166,3 +168,59 @@ class TestDeleter(unittest.TestCase):
         """Test that empty init arguments still work."""
         from trollmoves.server import Deleter
         Deleter(dict()).add('bla')
+
+
+config_file = b"""
+[eumetcast-hrit-0deg]
+origin = /local_disk/tellicast/received/MSGHRIT/H-000-{nominal_time:%Y%m%d%H%M}-{compressed:_<2s}
+request_port = 9094
+publisher_port = 9010
+info = sensor=seviri;variant=0DEG
+topic = /1b/hrit-segment/0deg
+delete = False
+"""
+
+
+class TestMoveItServer:
+    """Test the move it server."""
+
+    def test_reloads_config_crashes_when_config_file_does_not_exist(self):
+        """Test that reloading a non existing config file crashes."""
+        cmd_args = parse_args(["--port", "9999", "somefile99999.cfg"])
+        server = MoveItServer(cmd_args)
+        with pytest.raises(FileNotFoundError):
+            server.reload_cfg_file(cmd_args.config_file)
+
+    @patch("trollmoves.move_it_base.Publisher")
+    def test_reloads_config_on_example_config(self, fake_publisher):
+        """Test that config can be reloaded with basic example."""
+        with NamedTemporaryFile() as temporary_config_file:
+            temporary_config_file.write(config_file)
+            config_filename = temporary_config_file.name
+            cmd_args = parse_args(["--port", "9999", config_filename])
+            server = MoveItServer(cmd_args)
+            server.reload_cfg_file(cmd_args.config_file)
+
+    @patch("trollmoves.move_it_base.Publisher")
+    @patch("trollmoves.server.MoveItServer.reload_config")
+    def test_reloads_config_calls_reload_config(self, mock_reload_config, mock_publisher):
+        """Test that config file can be reloaded."""
+        with NamedTemporaryFile() as temporary_config_file:
+            temporary_config_file.write(config_file)
+            config_filename = temporary_config_file.name
+            cmd_args = parse_args(["--port", "9999", config_filename])
+            server = MoveItServer(cmd_args)
+            server.reload_cfg_file(cmd_args.config_file)
+            mock_reload_config.assert_called_once()
+
+    @patch("trollmoves.move_it_base.Publisher")
+    @patch("trollmoves.server.MoveItServer.reload_config")
+    def test_signal_reloads_config_calls_reload_config(self, mock_reload_config, mock_publisher):
+        """Test that config file can be reloaded through signal."""
+        with NamedTemporaryFile() as temporary_config_file:
+            temporary_config_file.write(config_file)
+            config_filename = temporary_config_file.name
+            cmd_args = parse_args([config_filename])
+            client = MoveItServer(cmd_args)
+            client.signal_reload_cfg_file()
+            mock_reload_config.assert_called_once()


### PR DESCRIPTION
This PR refactors the move it client/mirror/server to be more OOP complient, allowing easier future extensions.

This also adds some tests for the move it modules, in particular some acceptance tests doing some actual file-moving.

An extension is thus added here also to allow publishing messaged from the move it server side that include fsspec complient remote-filesystem specifications, for later use in trollflow2 and satpy.

This needs https://github.com/pytroll/pytroll-collectors/pull/104

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
