### PR TITLE
Add a mover for s3:// protocol

### DIFF
--- a/examples/move_it_client.ini
+++ b/examples/move_it_client.ini
@@ -74,3 +74,14 @@ topic = /1b/hrit-segment/0deg
 publish_port = 0
 # Wait a tiny bit of time when being a hot spare.  Delay is given in seconds.
 processing_delay = 0.02
+
+
+# Example config for requesting pushs to S3 object storage
+# Example of the connection settings are shown in the docstring of trollmoves.movers.S3Mover
+[eumetcast_hrit_0deg_s3]
+providers = satmottag:9010 satmottag2:9010 explorer:9010
+# Push to base of the bucket
+destination = s3://data-bucket/
+# Alternatively a sub-directory within the bucket. The directory structure will be created if it doesn't exist
+# destination = s3://data-bucket/msg/0deg
+topic = /1b/hrit-segment/0deg

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,18 @@
 from setuptools import setup
 import versioneer
 
+
+extras_require = {
+    's3': [
+        's3fs',
+    ]
+}
+
+all_extras = []
+for extra_deps in extras_require.values():
+    all_extras.extend(extra_deps)
+extras_require['all'] = list(set(all_extras))
+
 setup(name="trollmoves",
       version=versioneer.get_version(),
       description='Pytroll file utilities',
@@ -52,4 +64,5 @@ setup(name="trollmoves",
                         'trollsift', 'netifaces',
                         'pyzmq', 'inotify',
                         'scp', 'paramiko', 'pyyaml', 'watchdog'],
+      extras_require=extras_require,
       )

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -673,7 +673,6 @@ def _send_ack_message(msg, publisher):
 
 
 def _update_local_message(lmsg, _destination, login, response, **kwargs):
-    scheme = urlparse(_destination).scheme
     lmsg = make_uris(lmsg, _destination, login)
     lmsg.data['origin'] = response.data['request_address']
     lmsg.data.pop('request_address', None)

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -417,6 +417,8 @@ def create_push_req_message(msg, destination, login):
 def create_local_dir(destination, local_root, mode=0o777):
     """Create the local directory if it doesn't exist and return that path."""
     duri = urlparse(destination)
+    if duri.scheme in ('s3'):
+        return None
     local_dir = os.path.join(*([local_root] + duri.path.split(os.path.sep)))
 
     if not os.path.exists(local_dir):
@@ -470,7 +472,7 @@ def make_uris(msg, destination, login=None):
     duri = urlparse(destination)
     scheme = duri.scheme or 'ssh'
     dest_hostname = duri.hostname or socket.gethostname()
-    if socket.gethostbyname(dest_hostname) in get_local_ips():
+    if scheme not in ('s3') and socket.gethostbyname(dest_hostname) in get_local_ips():
         scheme_, host_ = "ssh", dest_hostname  # local file
     else:
         scheme_, host_ = scheme, dest_hostname  # remote file
@@ -625,7 +627,6 @@ def _request_files(huid, destination, login, publisher, **kwargs):
             LOGGER.debug("Server done sending file")
             add_to_file_cache(msg)
             _send_ack_message(msg, publisher)
-
             try:
                 lmsg = unpack_and_create_local_message(response, local_dir, **kwargs)
                 lmsg = _update_local_message(lmsg, _destination, login, response, **kwargs)
@@ -672,6 +673,7 @@ def _send_ack_message(msg, publisher):
 
 
 def _update_local_message(lmsg, _destination, login, response, **kwargs):
+    scheme = urlparse(_destination).scheme
     lmsg = make_uris(lmsg, _destination, login)
     lmsg.data['origin'] = response.data['request_address']
     lmsg.data.pop('request_address', None)

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -1431,3 +1431,57 @@ def test_replace_mda_for_mirror():
     kwargs = {'uri': '/another/path/{filename}.txt'}
     res = replace_mda(MSG_MIRROR, kwargs)
     assert res.data['uri'] == kwargs['uri']
+
+
+def test_create_local_dir():
+    """Test creation of local directory."""
+    from tempfile import mkdtemp
+    import shutil
+    from trollmoves.client import create_local_dir
+
+    destination = "ftp://server.foo/public_path/subdir/"
+    local_root = mkdtemp()
+    try:
+        res = create_local_dir(destination, local_root)
+        assert os.path.exists(res)
+    finally:
+        shutil.rmtree(local_root)
+
+
+def test_create_local_dir_s3():
+    """Test that nothing is done when destination is a S3 bucket."""
+    from trollmoves.client import create_local_dir
+
+    destination = "s3://data-bucket/public_path/subdir/"
+    res = create_local_dir(destination, "/foo/bar")
+    assert res is None
+
+
+def test_make_uris_local_destination():
+    """Test that the published messages are formulated correctly for local destinations."""
+    from trollmoves.client import make_uris
+
+    destination = "file://localhost/directory"
+    expected_uri = os.path.join(destination, "file1.png").replace("file://", "ssh://")
+    msg = make_uris(MSG_FILE, destination)
+    assert msg.data['uri'] == expected_uri
+
+
+def test_make_uris_remote_destination():
+    """Test that the published messages are formulated correctly for remote destinations."""
+    from trollmoves.client import make_uris
+
+    destination = "ftp://google.com/directory"
+    expected_uri = os.path.join(destination, "file1.png")
+    msg = make_uris(MSG_FILE, destination)
+    assert msg.data['uri'] == expected_uri
+
+
+def test_make_uris_s3_destination():
+    """Test that the published messages are formulated correctly for S3 destinations."""
+    from trollmoves.client import make_uris
+
+    destination = "s3://data-bucket/directory"
+    expected_uri = destination + "/" + "file1.png"
+    msg = make_uris(MSG_FILE, destination)
+    assert msg.data['uri'] == expected_uri

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -108,6 +108,6 @@ def test_s3_move(S3FileSystem):
     s3_mover.move()
     try:
         assert not os.path.exists(fname)
-    except AssertionError as err:
+    except AssertionError:
         os.remove(fname)
         raise OSError("File was not deleted after transfer.")


### PR DESCRIPTION
This PR adds a mover for `s3://` protocol, that is to S3 object storage. Some related adjustments were done to Trollmoves Client, including previously missing unit tests.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
