### PR TITLE
Add an option to disable target directory creation

### DIFF
--- a/examples/move_it_client.ini
+++ b/examples/move_it_client.ini
@@ -74,3 +74,6 @@ topic = /1b/hrit-segment/0deg
 publish_port = 0
 # Wait a tiny bit of time when being a hot spare.  Delay is given in seconds.
 processing_delay = 0.02
+# If the target location is on a remote host, the Client can't create the target directory.
+#     In this case, set the below option to False so that the creation isn't attempted.
+# create_target_directory = False


### PR DESCRIPTION
I'd want to move the Clients to servers that don't have access to the target filesystem. This isn't possible at the moment because target path creation is always attempted. This PR adds a new configuration option that can be used to disable it.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
