### PR TITLE
Make libraries required only by Trollmoves Server optional extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,14 @@ import versioneer
 extras_require = {
     's3': [
         's3fs',
-    ]
+    ],
+    'server': [
+        'inotify',
+        'paramiko',
+        'pyinotify',
+        'scp',
+        'watchdog',
+    ],
 }
 
 all_extras = []
@@ -60,9 +67,12 @@ setup(name="trollmoves",
       data_files=[],
       packages=['trollmoves'],
       zip_safe=False,
-      install_requires=['pyinotify', 'posttroll>=1.5.1',
-                        'trollsift', 'netifaces',
-                        'pyzmq', 'inotify',
-                        'scp', 'paramiko', 'pyyaml', 'watchdog'],
+      install_requires=[
+          'posttroll>=1.5.1',
+          'trollsift',
+          'netifaces',
+          'pyyaml',
+          'pyzmq',
+      ],
       extras_require=extras_require,
       )

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -35,16 +35,6 @@ import netrc
 
 from ftplib import FTP, all_errors, error_perm
 try:
-    from paramiko import SSHClient, SSHException, AutoAddPolicy
-except ImportError:
-    SSHClient = None
-    SSHException = None
-    AutoAddPolicy = None
-try:
-    from scp import SCPClient
-except ImportError:
-    SCPClient = None
-try:
     from s3fs import S3FileSystem
 except ImportError:
     S3FileSystem = None
@@ -306,8 +296,8 @@ class ScpMover(Mover):
 
     def open_connection(self):
         """Open a connection."""
-        if SSHClient is None or SCPClient is None:
-            raise ImportError("ScpMover needs 'paramiko' and 'scp' to be installed.")
+        from paramiko import SSHClient, SSHException, AutoAddPolicy
+
         retries = 3
         ssh_key_filename = self.attrs.get("ssh_key_filename", None)
         while retries > 0:
@@ -364,6 +354,8 @@ class ScpMover(Mover):
 
     def copy(self):
         """Upload the file."""
+        from scp import SCPClient
+
         ssh_connection = self.get_connection(self.destination.hostname,
                                              self.destination.port or 22,
                                              self._dest_username)


### PR DESCRIPTION
To reduce the size of a Trollmoves Client container image, make the libraries used only by the Server optional extras.

This also means that a full installation would need `pip install 'trollmoves[all]'` or omitting S3 parts `pip install 'trollmoves[server]'`.