### PR TITLE
Use dictionary config interfaces for publisher and subscriber creation

### DIFF
--- a/trollmoves/__init__.py
+++ b/trollmoves/__init__.py
@@ -1,4 +1,8 @@
+"""The Trollmoves package."""
 
 from .version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+FALSY = ["", "False", "false", "0", "off", "no"]
+TRUTHY = ["True", "true", "on", "1", "yes"]

--- a/trollmoves/__init__.py
+++ b/trollmoves/__init__.py
@@ -3,6 +3,3 @@
 from .version import get_versions
 __version__ = get_versions()['version']
 del get_versions
-
-FALSY = ["", "False", "false", "0", "off", "no"]
-TRUTHY = ["True", "true", "on", "1", "yes"]

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -45,6 +45,8 @@ from posttroll.publisher import create_publisher_from_dict_config
 from posttroll.subscriber import Subscriber
 from trollsift.parser import compose
 
+from trollmoves import FALSY
+from trollmoves import TRUTHY
 from trollmoves import heartbeat_monitor
 from trollmoves.utils import get_local_ips
 from trollmoves.utils import gen_dict_extract, translate_dict
@@ -102,10 +104,6 @@ def _set_config_defaults(conf):
     conf.setdefault("transfer_req_timeout", 10 * DEFAULT_REQ_TIMEOUT)
     conf.setdefault("nameservers", None)
     conf.setdefault("create_target_directory", True)
-
-
-FALSY = ["", "False", "false", "0", "off"]
-TRUTHY = ["True", "true", "on", "1"]
 
 
 def _parse_boolean_config_items(conf):

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -431,11 +431,15 @@ class Listener(Thread):
         nameserver = self.attrs.get('nameserver')
         if nameserver in ('false', 'False'):
             nameserver = False
+        addresses = self.attrs.get('adrresses')
+        if addresses:
+            addresses = addresses.split()
+
         with Subscribe(
             services=self.attrs.get('services', ''),
             topics=self.attrs.get('topics', self.attrs['listen']),
             addr_listener=bool(self.attrs.get('addr_listener', True)),
-            addresses=self.attrs.get('addresses'),
+            addresses=addresses,
             timeout=int(self.attrs.get('timeout')),
             translate=bool(self.attrs.get('translate', False)),
             nameserver=nameserver,

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -433,7 +433,7 @@ class Listener(Thread):
         nameserver = self.attrs.get('nameserver')
         if nameserver in FALSY:
             nameserver = False
-        addresses = self.attrs.get('adrresses')
+        addresses = self.attrs.get('addresses')
         if addresses:
             addresses = addresses.split()
 
@@ -442,7 +442,7 @@ class Listener(Thread):
             topics=self.attrs.get('topics', self.attrs['listen']),
             addr_listener=bool(self.attrs.get('addr_listener', True)),
             addresses=addresses,
-            timeout=int(self.attrs.get('timeout')),
+            timeout=int(self.attrs.get('timeout', 10)),
             translate=bool(self.attrs.get('translate', False)),
             nameserver=nameserver,
         ) as sub:

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -52,6 +52,8 @@ from posttroll.publisher import get_own_ip
 from posttroll.subscriber import Subscribe
 from trollsift import globify, parse
 
+from trollmoves import FALSY
+from trollmoves import TRUTHY
 from trollmoves.client import DEFAULT_REQ_TIMEOUT
 from trollmoves.movers import move_it
 from trollmoves.utils import (clean_url, gen_dict_contains, gen_dict_extract,
@@ -257,7 +259,7 @@ class RequestManager(Thread):
             self._deleter.add(pathname)
 
     def _is_delete_set(self):
-        return self._attrs.get('delete', 'False').lower() in ["1", "yes", "true", "on"]
+        return self._attrs.get('delete', 'False').lower() in TRUTHY
 
     def ack(self, message):
         """Reply with ack to a publication."""
@@ -429,7 +431,7 @@ class Listener(Thread):
     def run(self):
         """Start listening to messages."""
         nameserver = self.attrs.get('nameserver')
-        if nameserver in ('false', 'False'):
+        if nameserver in FALSY:
             nameserver = False
         addresses = self.attrs.get('adrresses')
         if addresses:

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -428,7 +428,18 @@ class Listener(Thread):
 
     def run(self):
         """Start listening to messages."""
-        with Subscribe('', topics=self.attrs['listen'], addr_listener=True) as sub:
+        nameserver = self.attrs.get('nameserver')
+        if nameserver in ('false', 'False'):
+            nameserver = False
+        with Subscribe(
+            services=self.attrs.get('services', ''),
+            topics=self.attrs.get('topics', self.attrs['listen']),
+            addr_listener=bool(self.attrs.get('addr_listener', True)),
+            addresses=self.attrs.get('addresses'),
+            timeout=int(self.attrs.get('timeout')),
+            translate=bool(self.attrs.get('translate', False)),
+            nameserver=nameserver,
+        ) as sub:
             self._run(sub)
 
     def _run(self, sub):

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -52,8 +52,6 @@ from posttroll.publisher import get_own_ip
 from posttroll.subscriber import Subscribe
 from trollsift import globify, parse
 
-from trollmoves import FALSY
-from trollmoves import TRUTHY
 from trollmoves.client import DEFAULT_REQ_TIMEOUT
 from trollmoves.movers import move_it
 from trollmoves.utils import (clean_url, gen_dict_contains, gen_dict_extract,
@@ -255,11 +253,8 @@ class RequestManager(Thread):
         return error_message
 
     def _add_to_deleter(self, pathname):
-        if self._attrs.get('compression') or self._is_delete_set():
+        if self._attrs.get('compression') or self._attrs['delete']:
             self._deleter.add(pathname)
-
-    def _is_delete_set(self):
-        return self._attrs.get('delete', 'False').lower() in TRUTHY
 
     def ack(self, message):
         """Reply with ack to a publication."""
@@ -430,21 +425,14 @@ class Listener(Thread):
 
     def run(self):
         """Start listening to messages."""
-        nameserver = self.attrs.get('nameserver')
-        if nameserver in FALSY:
-            nameserver = False
-        addresses = self.attrs.get('addresses')
-        if addresses:
-            addresses = addresses.split()
-
         with Subscribe(
             services=self.attrs.get('services', ''),
             topics=self.attrs.get('topics', self.attrs['listen']),
             addr_listener=bool(self.attrs.get('addr_listener', True)),
-            addresses=addresses,
+            addresses=self.attrs.get('addresses'),
             timeout=int(self.attrs.get('timeout', 10)),
             translate=bool(self.attrs.get('translate', False)),
-            nameserver=nameserver,
+            nameserver=self.attrs.get('nameserver'),
         ) as sub:
             self._run(sub)
 
@@ -523,6 +511,10 @@ class WatchdogHandler(FileSystemEventHandler):
 
 def read_config(filename):
     """Read the config file called *filename*."""
+    return _read_ini_config(filename)
+
+
+def _read_ini_config(filename):
     cp_ = RawConfigParser()
     cp_.read(filename)
 
@@ -531,6 +523,9 @@ def read_config(filename):
     for section in cp_.sections():
         res[section] = dict(cp_.items(section))
         _set_config_defaults(res[section])
+        _parse_nameserver(res[section], cp_[section])
+        _parse_addresses(res[section])
+        _parse_delete(res[section], cp_[section])
         if not _check_origin_and_listen(res, section):
             continue
         if not _check_topic(res, section):
@@ -545,6 +540,28 @@ def _set_config_defaults(conf):
     conf.setdefault("req_timeout", DEFAULT_REQ_TIMEOUT)
     conf.setdefault("transfer_req_timeout", 10 * DEFAULT_REQ_TIMEOUT)
     conf.setdefault("ssh_key_filename", None)
+    conf.setdefault("delete", False)
+
+
+def _parse_nameserver(conf, raw_conf):
+    try:
+        val = raw_conf.getboolean("nameserver")
+    except ValueError:
+        val = conf["nameserver"]
+    conf["nameserver"] = val
+
+
+def _parse_addresses(conf):
+    val = conf.get("addresses")
+    if isinstance(val, str):
+        val = val.split()
+    conf["addresses"] = val
+
+
+def _parse_delete(conf, raw_conf):
+    val = raw_conf.getboolean("delete")
+    if val is not None:
+        conf["delete"] = val
 
 
 def _check_origin_and_listen(res, section):

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -159,6 +159,7 @@ CHAIN_BASIC_CONFIG = {"login": "user:pass", "topic": "/foo", "publish_port": 123
 
 @pytest.fixture
 def listener():
+    """Create a fixture for a listener."""
     with patch('trollmoves.client.CTimer'):
         with patch('trollmoves.heartbeat_monitor.Monitor'):
             with patch('trollmoves.client.Subscriber'):
@@ -170,6 +171,7 @@ def listener():
 
 @pytest.fixture
 def delayed_listener():
+    """Create a fixture for a delayed listener."""
     with patch('trollmoves.client.CTimer'):
         with patch('trollmoves.heartbeat_monitor.Monitor'):
             with patch('trollmoves.client.Subscriber'):
@@ -207,51 +209,61 @@ def _write_to_tar(file_to_add, remove_in_file=False, filename=None):
 
 @pytest.fixture
 def client_config_1_item():
+    """Create a fixture for a client config."""
     yield _write_named_temporary_config(CLIENT_CONFIG_1_ITEM)
 
 
 @pytest.fixture
 def client_config_1_item_non_pub_provider_item_modified():
+    """Create a fixture for a client config."""
     yield _write_named_temporary_config(CLIENT_CONFIG_1_ITEM_NON_PUB_PROVIDER_ITEM_MODIFIED)
 
 
 @pytest.fixture
 def client_config_1_item_two_providers():
+    """Create a fixture for a client config."""
     yield _write_named_temporary_config(CLIENT_CONFIG_1_ITEM_TWO_PROVIDERS)
 
 
 @pytest.fixture
 def client_config_1_item_topic_changed():
+    """Create a fixture for a client config."""
     yield _write_named_temporary_config(CLIENT_CONFIG_1_ITEM_TOPIC_CHANGED)
 
 
 @pytest.fixture
 def client_config_1_pub_item_modified():
+    """Create a fixture for a client config."""
     yield _write_named_temporary_config(CLIENT_CONFIG_1_PUB_ITEM_MODIFIED)
 
 
 @pytest.fixture
 def client_config_2_items():
+    """Create a fixture for a client config."""
     yield _write_named_temporary_config(CLIENT_CONFIG_2_ITEMS)
 
 
 @pytest.fixture
 def compression_config():
+    """Create a fixture for compression config."""
     yield _write_named_temporary_config(COMPRESSION_CONFIG)
 
 
 @pytest.fixture
 def test_txt_file_1():
+    """Create a fixture for text file."""
     yield _write_named_temporary_config("test 1\n")
 
 
 @pytest.fixture
 def test_txt_file_2():
+    """Create a fixture for text file."""
     yield _write_named_temporary_config("test 2\n")
 
 
 @pytest.fixture
 def chain_config_with_one_item(client_config_1_item):
+    """Create a fixture for confif with one item."""
     from trollmoves.client import read_config
 
     try:
@@ -939,9 +951,9 @@ def test_read_config(client_config_1_item):
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_single_chain(Listener, NoisyPublisher, request_push, client_config_1_item):
+def test_reload_config_single_chain(Listener, create_publisher_from_dict_config, request_push, client_config_1_item):
     """Test trollmoves.client.reload_config() with a single chain."""
     from trollmoves.client import reload_config
 
@@ -951,7 +963,7 @@ def test_reload_config_single_chain(Listener, NoisyPublisher, request_push, clie
         reload_config(client_config_1_item, chains)
         assert len(chains) == 1
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
-        assert NoisyPublisher.call_count == 1
+        assert create_publisher_from_dict_config.call_count == 1
         assert Listener.call_count == 4
     finally:
         _stop_chains(chains)
@@ -959,9 +971,10 @@ def test_reload_config_single_chain(Listener, NoisyPublisher, request_push, clie
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, client_config_1_item, client_config_2_items):
+def test_reload_config_chain_added(Listener, create_publisher_from_dict_config, request_push,
+                                   client_config_1_item, client_config_2_items):
     """Test trollmoves.client.reload_config() when a chain is added."""
     from trollmoves.client import reload_config
 
@@ -973,7 +986,7 @@ def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, clien
         assert len(chains) == 2
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
         assert "foo" in chains
-        assert NoisyPublisher.call_count == 2
+        assert create_publisher_from_dict_config.call_count == 2
         assert Listener.call_count == 5
     finally:
         _stop_chains(chains)
@@ -982,9 +995,9 @@ def test_reload_config_chain_added(Listener, NoisyPublisher, request_push, clien
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_chain_removed(Listener, NoisyPublisher, request_push,
+def test_reload_config_chain_removed(Listener, create_publisher_from_dict_config, request_push,
                                      client_config_1_item, client_config_2_items):
     """Test trollmoves.client.reload_config() when a chain is added."""
     from trollmoves.client import reload_config
@@ -997,7 +1010,7 @@ def test_reload_config_chain_removed(Listener, NoisyPublisher, request_push,
         assert len(chains) == 1
         assert "eumetcast_hrit_0deg_scp_hot_spare" in chains
         assert "foo" not in chains
-        assert NoisyPublisher.call_count == 2
+        assert create_publisher_from_dict_config.call_count == 2
         assert Listener.call_count == 5
     finally:
         _stop_chains(chains)
@@ -1014,9 +1027,10 @@ def _stop_chains(chains):
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_publisher_items_not_changed(Listener, create_publisher_from_dict_config, request_push,
+                                                   client_config_1_item,
                                                    client_config_1_item_non_pub_provider_item_modified):
     """Test trollmoves.client.reload_config() when other than publisher related items are changed."""
     from trollmoves.client import reload_config
@@ -1025,9 +1039,9 @@ def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, req
 
     try:
         reload_config(client_config_1_item, chains)
-        NoisyPublisher.assert_called_once()
+        create_publisher_from_dict_config.assert_called_once()
         reload_config(client_config_1_item_non_pub_provider_item_modified, chains)
-        NoisyPublisher.assert_called_once()
+        create_publisher_from_dict_config.assert_called_once()
     finally:
         _stop_chains(chains)
         os.remove(client_config_1_item)
@@ -1035,9 +1049,10 @@ def test_reload_config_publisher_items_not_changed(Listener, NoisyPublisher, req
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_publisher_items_changed(Listener, create_publisher_from_dict_config, request_push,
+                                               client_config_1_item,
                                                client_config_1_pub_item_modified):
     """Test trollmoves.client.reload_config() when publisher related items are changed."""
     from trollmoves.client import reload_config
@@ -1046,9 +1061,9 @@ def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, request
 
     try:
         reload_config(client_config_1_item, chains)
-        NoisyPublisher.assert_called_once()
+        create_publisher_from_dict_config.assert_called_once()
         reload_config(client_config_1_pub_item_modified, chains)
-        assert NoisyPublisher.call_count == 2
+        assert create_publisher_from_dict_config.call_count == 2
     finally:
         _stop_chains(chains)
         os.remove(client_config_1_item)
@@ -1056,9 +1071,10 @@ def test_reload_config_publisher_items_changed(Listener, NoisyPublisher, request
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_not_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_providers_not_changed(Listener, create_publisher_from_dict_config, request_push,
+                                             client_config_1_item,
                                              client_config_1_item_non_pub_provider_item_modified):
     """Test trollmoves.client.reload_config() when other than provider related options are changed."""
     from trollmoves.client import reload_config
@@ -1078,9 +1094,9 @@ def test_reload_config_providers_not_changed(Listener, NoisyPublisher, request_p
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_added(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_providers_added(Listener, create_publisher_from_dict_config, request_push, client_config_1_item,
                                        client_config_1_item_two_providers):
     """Test trollmoves.client.reload_config() when providers are added."""
     from trollmoves.client import reload_config
@@ -1108,9 +1124,10 @@ def _check_providers_listeners_and_listener_calls(chains, Listener, call_count=N
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_providers_removed(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_providers_removed(Listener, create_publisher_from_dict_config, request_push,
+                                         client_config_1_item,
                                          client_config_1_item_two_providers):
     """Test trollmoves.client.reload_config() when providers are removed."""
     from trollmoves.client import reload_config
@@ -1134,9 +1151,10 @@ def test_reload_config_providers_removed(Listener, NoisyPublisher, request_push,
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_reload_config_provider_topic_changed(Listener, NoisyPublisher, request_push, client_config_1_item,
+def test_reload_config_provider_topic_changed(Listener, create_publisher_from_dict_config, request_push,
+                                              client_config_1_item,
                                               client_config_1_item_topic_changed):
     """Test trollmoves.client.reload_config() when the message topic is changed."""
     from trollmoves.client import reload_config
@@ -1232,24 +1250,24 @@ def _mock_listener_for_chain_tests(Listener, is_alive=True):
     return side_effect
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_init(Listener, NoisyPublisher, chain_config_with_one_item):
+def test_chain_init(Listener, create_publisher_from_dict_config, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
 
     name = 'eumetcast_hrit_0deg_scp_hot_spare'
     chain = Chain(name, chain_config_with_one_item[name])
 
-    NoisyPublisher.assert_called_once()
+    create_publisher_from_dict_config.assert_called_once()
     assert chain.listeners == {}
     assert not chain.listener_died_event.is_set()
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_listeners(Listener, NoisyPublisher, request_push, chain_config_with_one_item):
+def test_chain_listeners(Listener, create_publisher_from_dict_config, request_push, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
 
@@ -1263,9 +1281,10 @@ def test_chain_listeners(Listener, NoisyPublisher, request_push, chain_config_wi
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_restart_dead_listeners(Listener, NoisyPublisher, request_push, caplog, chain_config_with_one_item):
+def test_chain_restart_dead_listeners(Listener, create_publisher_from_dict_config, request_push, caplog,
+                                      chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
     import trollmoves.client
@@ -1296,9 +1315,10 @@ def test_chain_restart_dead_listeners(Listener, NoisyPublisher, request_push, ca
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_listener_crashing_once(Listener, NoisyPublisher, request_push, caplog, chain_config_with_one_item):
+def test_chain_listener_crashing_once(Listener, create_publisher_from_dict_config, request_push, caplog,
+                                      chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
     import trollmoves.client
@@ -1326,9 +1346,9 @@ def test_chain_listener_crashing_once(Listener, NoisyPublisher, request_push, ca
 
 
 @patch('trollmoves.client.request_push')
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_listener_crashing_all_the_time(Listener, NoisyPublisher, request_push,
+def test_chain_listener_crashing_all_the_time(Listener, create_publisher_from_dict_config, request_push,
                                               caplog, chain_config_with_one_item):
     """Test the Chain object."""
     from trollmoves.client import Chain
@@ -1354,9 +1374,9 @@ def test_chain_listener_crashing_all_the_time(Listener, NoisyPublisher, request_
             chain.stop()
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_get_unchanged_providers(Listener, NoisyPublisher):
+def test_chain_get_unchanged_providers(Listener, create_publisher_from_dict_config):
     """Test the get_unchanged_providers() method in Chain object."""
     from trollmoves.client import Chain
 
@@ -1370,9 +1390,9 @@ def test_chain_get_unchanged_providers(Listener, NoisyPublisher):
     assert set(res).difference(config2["providers"]) == set()
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_get_unchanged_providers_topic_changed(Listener, NoisyPublisher):
+def test_chain_get_unchanged_providers_topic_changed(Listener, create_publisher_from_dict_config):
     """Test the get_unchanged_providers() method in Chain object when topic changes."""
     from trollmoves.client import Chain
 
@@ -1384,9 +1404,9 @@ def test_chain_get_unchanged_providers_topic_changed(Listener, NoisyPublisher):
     assert chain.get_unchanged_providers(config2) == []
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_publisher_needs_restarting_no_change(Listener, NoisyPublisher):
+def test_chain_publisher_needs_restarting_no_change(Listener, create_publisher_from_dict_config):
     """Test the publisher_needs_restarting() method of Chain object when nothing changes."""
     from trollmoves.client import Chain
 
@@ -1395,9 +1415,9 @@ def test_chain_publisher_needs_restarting_no_change(Listener, NoisyPublisher):
     assert chain.publisher_needs_restarting(config.copy()) is False
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_publisher_needs_restarting_non_publisher_value_modified(Listener, NoisyPublisher):
+def test_chain_publisher_needs_restarting_non_publisher_value_modified(Listener, create_publisher_from_dict_config):
     """Test the publisher_needs_restarting() method of Chain object when a value not related to Publisher is changed."""
     from trollmoves.client import Chain
 
@@ -1407,9 +1427,9 @@ def test_chain_publisher_needs_restarting_non_publisher_value_modified(Listener,
     assert chain.publisher_needs_restarting(config.copy()) is False
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_publisher_needs_restarting_non_publisher_value_added(Listener, NoisyPublisher):
+def test_chain_publisher_needs_restarting_non_publisher_value_added(Listener, create_publisher_from_dict_config):
     """Test the publisher_needs_restarting() method of Chain object when a value not related to Publisher is added."""
     from trollmoves.client import Chain
 
@@ -1419,9 +1439,9 @@ def test_chain_publisher_needs_restarting_non_publisher_value_added(Listener, No
     assert chain.publisher_needs_restarting(config.copy()) is False
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_publisher_needs_restarting_nameservers_modified(Listener, NoisyPublisher):
+def test_chain_publisher_needs_restarting_nameservers_modified(Listener, create_publisher_from_dict_config):
     """Test the publisher_needs_restarting() method of Chain object when nameservers are modified."""
     from trollmoves.client import Chain
 
@@ -1431,9 +1451,9 @@ def test_chain_publisher_needs_restarting_nameservers_modified(Listener, NoisyPu
     assert chain.publisher_needs_restarting(config.copy()) is True
 
 
-@patch('trollmoves.client.NoisyPublisher')
+@patch('trollmoves.client.create_publisher_from_dict_config')
 @patch('trollmoves.client.Listener')
-def test_chain_publisher_needs_restarting_port_modified(Listener, NoisyPublisher):
+def test_chain_publisher_needs_restarting_port_modified(Listener, create_publisher_from_dict_config):
     """Test the publisher_needs_restarting() method of Chain object when publish port is modified."""
     from trollmoves.client import Chain
 

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -161,6 +161,7 @@ destination = scp:///tmp/foo
 login = user
 topic = /1b/hrit-segment/0deg
 publish_port = 0
+nameservers = ns1 ns2
 """
 
 LOCAL_DIR = "/local"
@@ -1569,3 +1570,25 @@ def test_make_uris_s3_destination():
     expected_uri = destination + "/" + "file1.png"
     msg = make_uris(MSG_FILE, destination)
     assert msg.data['uri'] == expected_uri
+
+
+def test_read_config_nameservers_is_false(client_config_1_item_nameservers_is_false):
+    """Test config reading when nameservers is set to False."""
+    from trollmoves.client import read_config
+
+    try:
+        conf = read_config(client_config_1_item_nameservers_is_false)
+    finally:
+        os.remove(client_config_1_item_nameservers_is_false)
+    assert conf['eumetcast_hrit_0deg_scp_hot_spare']['nameservers'] is False
+
+
+def test_read_config_nameservers_are_a_list_or_tuple(client_config_2_items):
+    """Test that two nameservers are given as a list or a tuple."""
+    from trollmoves.client import read_config
+
+    try:
+        conf = read_config(client_config_2_items)
+    finally:
+        os.remove(client_config_2_items)
+    assert isinstance(conf['foo']['nameservers'], (list, tuple))

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -22,7 +22,7 @@
 
 """Test Trollmoves server."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 import unittest
 from tempfile import TemporaryDirectory
 import os
@@ -166,3 +166,25 @@ class TestDeleter(unittest.TestCase):
         """Test that empty init arguments still work."""
         from trollmoves.server import Deleter
         Deleter(dict()).add('bla')
+
+
+@patch("trollmoves.server.Listener._run")
+@patch("trollmoves.server.Subscribe")
+def test_listener_subscribe_default_settings(Subscribe, _run):
+    """Test the default usage of trollmoves.server.Listener."""
+    from trollmoves.server import Listener
+
+    attrs = {'listen': '/topic'}
+    publisher = 'foo'
+    expected = call(
+        services='',
+        topics=attrs['listen'],
+        addr_listener=True,
+        addresses=None,
+        timeout=10,
+        translate=False,
+        nameserver=None,
+    )
+    listener = Listener(attrs, publisher)
+    listener.run()
+    assert expected in Subscribe.mock_calls


### PR DESCRIPTION
This PR makes it possible to:
- disable `nameserver` connections by defining `nameservers = False` (Client) or `nameserver = False` and `addresses = srvr1:12345 srvr2:12345` (Server, when using posttroll notifier) in the configuration file
- pass all the `NSSubscriber` parameters by defining them in the Server configuration file when using posttroll notifier

The default behavior isn't affected.

 - [x] Tests adjusted  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
