### PR TITLE
Separate install requirements for 3rd party packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ extras_require = {
     'dispatcher': [
         'inotify',
         'netifaces',
+        'posttroll>=1.5.1',
         'pyyaml',
         'trollsift',
     ],

--- a/setup.py
+++ b/setup.py
@@ -26,14 +26,44 @@ import versioneer
 
 
 extras_require = {
+    'client': [
+        'netifaces',
+        'posttroll>=1.5.1',
+        'pyinotify',
+        'pyzmq',
+        'trollsift',
+    ],
+    'dispatcher': [
+        'inotify',
+        'netifaces',
+        'pyyaml',
+        'trollsift',
+    ],
+    'mirror': [
+        'netifaces',
+        'posttroll>=1.5.1',
+        'pyinotify',
+        'pyzmq',
+        'trollsift',
+        'watchdog',
+    ],
     's3': [
         's3fs',
     ],
-    'server': [
-        'inotify',
+    'scp': [
         'paramiko',
         'scp',
+    ],
+    'server': [
+        'netifaces',
+        'posttroll>=1.5.1',
+        'pyinotify',
+        'pyzmq',
+        'trollsift',
         'watchdog',
+    ],
+    'sftp': [
+        'paramiko',
     ],
 }
 
@@ -66,13 +96,6 @@ setup(name="trollmoves",
       data_files=[],
       packages=['trollmoves'],
       zip_safe=False,
-      install_requires=[
-          'posttroll>=1.5.1',
-          'trollsift',
-          'netifaces',
-          'pyinotify',
-          'pyyaml',
-          'pyzmq',
-      ],
+      install_requires=[],
       extras_require=extras_require,
       )

--- a/trollmoves/dispatcher.py
+++ b/trollmoves/dispatcher.py
@@ -166,8 +166,9 @@ from posttroll.publisher import NoisyPublisher
 from posttroll.message import Message
 from trollsift import compose
 
+from trollmoves.client import is_file_local
 from trollmoves.movers import move_it
-from trollmoves.utils import (clean_url, is_file_local)
+from trollmoves.utils import clean_url
 
 logger = logging.getLogger(__name__)
 

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -53,9 +53,9 @@ from posttroll.subscriber import Subscribe
 from trollsift import globify, parse
 
 from trollmoves.client import DEFAULT_REQ_TIMEOUT
+from trollmoves.client import is_file_local
 from trollmoves.movers import move_it
-from trollmoves.utils import (clean_url, gen_dict_contains, gen_dict_extract,
-                              is_file_local)
+from trollmoves.utils import (clean_url, gen_dict_contains, gen_dict_extract)
 from trollmoves.move_it_base import MoveItBase, create_publisher, EventHandler
 
 LOGGER = logging.getLogger(__name__)

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -22,13 +22,7 @@
 
 """Utility functions for Trollmoves."""
 
-import socket
 from urllib.parse import urlparse, urlunparse
-
-try:
-    import netifaces
-except ImportError:
-    netifaces = None
 
 
 def clean_url(url):
@@ -39,20 +33,6 @@ def clean_url(url):
         urlobj = url
     return urlunparse((urlobj.scheme, urlobj.hostname,
                        urlobj.path, "", "", ""))
-
-
-def get_local_ips():
-    """Get the ips of the current machine."""
-    if netifaces is None:
-        raise ImportError("get_local_ips() requires 'netifaces' to be installed.")
-    inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
-                  for iface in netifaces.interfaces()]
-    ips = []
-    for addr in inet_addrs:
-        if addr is not None:
-            for add in addr:
-                ips.append(add['addr'])
-    return ips
 
 
 def gen_dict_extract(var, key):
@@ -136,11 +116,3 @@ def translate_dict(var, keys, callback, **kwargs):
         return newvar
     else:
         return var
-
-
-def is_file_local(urlobj):
-    """Check that a url path is for a local file."""
-    if urlobj.scheme not in ['', 'file'] and not socket.gethostbyname(urlobj.netloc) in get_local_ips():
-        return False
-
-    return True

--- a/trollmoves/utils.py
+++ b/trollmoves/utils.py
@@ -19,10 +19,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utility functions for Trollmoves."""
+
 import socket
 from urllib.parse import urlparse, urlunparse
 
-import netifaces
+try:
+    import netifaces
+except ImportError:
+    netifaces = None
 
 
 def clean_url(url):
@@ -37,6 +43,8 @@ def clean_url(url):
 
 def get_local_ips():
     """Get the ips of the current machine."""
+    if netifaces is None:
+        raise ImportError("get_local_ips() requires 'netifaces' to be installed.")
     inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
                   for iface in netifaces.interfaces()]
     ips = []
@@ -48,6 +56,7 @@ def get_local_ips():
 
 
 def gen_dict_extract(var, key):
+    """Exctract a value from dictionary."""
     if hasattr(var, 'items'):
         for k, v in var.items():
             if k == key:
@@ -62,6 +71,7 @@ def gen_dict_extract(var, key):
 
 
 def gen_dict_contains(var, key):
+    """Check dictionary containing an item."""
     if hasattr(var, 'items'):
         for k, v in var.items():
             if k == key:
@@ -76,6 +86,7 @@ def gen_dict_contains(var, key):
 
 
 def translate_dict_value(var, key, callback):
+    """Translate dictionary values."""
     newvar = var.copy()
     if hasattr(var, 'items'):
         for k, v in var.items():
@@ -91,6 +102,7 @@ def translate_dict_value(var, key, callback):
 
 
 def translate_dict_item(var, key, callback):
+    """Translate dictionary items."""
     newvar = var.copy()
     if hasattr(var, 'items'):
         for k, v in var.items():
@@ -106,6 +118,7 @@ def translate_dict_item(var, key, callback):
 
 
 def translate_dict(var, keys, callback, **kwargs):
+    """Translate dictionary."""
     try:
         newvar = var.copy()
     except AttributeError:
@@ -127,7 +140,7 @@ def translate_dict(var, keys, callback, **kwargs):
 
 def is_file_local(urlobj):
     """Check that a url path is for a local file."""
-    if(urlobj.scheme not in ['', 'file'] and not socket.gethostbyname(urlobj.netloc) in get_local_ips()):
+    if urlobj.scheme not in ['', 'file'] and not socket.gethostbyname(urlobj.netloc) in get_local_ips():
         return False
 
     return True


### PR DESCRIPTION
This PR is an attempt to make it possible to use as small portions of Trollmoves as possible.

As an example, https://github.com/pytroll/pytroll-collectors/pull/117 would only require the `S3Mover` with its install requirements, so installation of all the other 3rd party libraries would be unnecessary.

Another PR that starts the documentation: https://github.com/pytroll/trollmoves/pull/130

 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
