### PR TITLE
Refactor the logging

### DIFF
--- a/bin/dispatcher.py
+++ b/bin/dispatcher.py
@@ -27,49 +27,10 @@ configuration file can be triggered with a `kill -10 <dispatcher pid>`.
 """
 
 import argparse
-import logging
-import logging.config
-import logging.handlers
-import os
 import sys
 
-import yaml
-
 from trollmoves.dispatcher import Dispatcher
-
-LOG_FORMAT = "[%(asctime)s %(levelname)-8s] %(message)s"
-logger = logging.getLogger('dispatcher')
-
-log_levels = {
-    0: logging.WARN,
-    1: logging.INFO,
-    2: logging.DEBUG,
-}
-
-
-def setup_logging(cmd_args):
-    """Set up logging."""
-    if cmd_args.log_config is not None:
-        with open(cmd_args.log_config) as fd:
-            log_dict = yaml.safe_load(fd.read())
-            logging.config.dictConfig(log_dict)
-            return
-
-    root = logging.getLogger('')
-    root.setLevel(log_levels[cmd_args.verbosity])
-
-    if cmd_args.log:
-        fh_ = logging.handlers.TimedRotatingFileHandler(
-            os.path.join(cmd_args.log),
-            "midnight",
-            backupCount=7)
-    else:
-        fh_ = logging.StreamHandler()
-
-    formatter = logging.Formatter(LOG_FORMAT)
-    fh_.setFormatter(formatter)
-
-    root.addHandler(fh_)
+from trollmoves.logging import setup_logging, add_logging_options_to_parser
 
 
 def parse_args():
@@ -77,14 +38,6 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("config_file",
                         help="The configuration file to run on.")
-    parser.add_argument("-l", "--log",
-                        help="The file to log to. stdout otherwise.")
-    parser.add_argument("-c", "--log-config",
-                        help="Log config file to use instead of the standard logging.")
-    parser.add_argument("-v", "--verbose", dest="verbosity", action="count", default=0,
-                        help="Verbosity (between 1 and 2 occurrences with more leading to more "
-                        "verbose logging). WARN=0, INFO=1, "
-                        "DEBUG=2. This is overridden by the log config file if specified.")
     parser.add_argument(
         "-p", "--publish-port", type=int, dest="pub_port", nargs='?',
         const=0, default=None,
@@ -93,13 +46,14 @@ def parse_args():
     parser.add_argument("-n", "--publish-nameserver", nargs='*',
                         dest="pub_nameservers",
                         help="Nameserver for publisher to connect to")
+    add_logging_options_to_parser(parser, legacy=True)
     return parser.parse_args()
 
 
 def main():
     """Start and run the dispatcher."""
     cmd_args = parse_args()
-    setup_logging(cmd_args)
+    logger = setup_logging("dispatcher", cmd_args)
     logger.info("Starting up.")
 
     try:

--- a/bin/move_it_client.py
+++ b/bin/move_it_client.py
@@ -68,34 +68,32 @@ For example::
 Logging
 -------
 
-The logging is done on stdout per default. It is however possible to specify a file to log to (instead of stdout)
-with the -l or --log option::
+The logging is done on stdout per default. It is however possible to specify a logging config file with the -c
+or --log-config option::
 
-  move_it_client --log /path/to/mylogfile.log myconfig.ini
+  move_it_client --log-config /path/to/mylogconfig.yaml myconfig.ini
 
 """
 
 # TODO: implement ping and server selection
-import logging.handlers
 
 from trollmoves.client import parse_args, MoveItClient
-
-LOGGER = logging.getLogger("move_it_client")
-LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
+from trollmoves.logging import setup_logging
 
 
 def main():
     """Run the Trollmoves Client."""
     cmd_args = parse_args()
+    logger = setup_logging("move_it_client", cmd_args)
     client = MoveItClient(cmd_args)
 
     try:
         client.reload_cfg_file(cmd_args.config_file)
         client.run()
     except KeyboardInterrupt:
-        LOGGER.debug("Interrupting")
+        logger.debug("Interrupting")
     except Exception as err:
-        LOGGER.exception(err)
+        logger.exception(err)
     finally:
         if client.running:
             client.chains_stop()

--- a/bin/move_it_mirror.py
+++ b/bin/move_it_mirror.py
@@ -21,25 +21,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Move it Mirror."""
-
-import logging.handlers
-
+from trollmoves.logging import setup_logging
 from trollmoves.mirror import MoveItMirror, parse_args
-
-LOGGER = logging.getLogger("move_it_mirror")
-LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
 
 
 def main():
     """Start the mirroring."""
     cmd_args = parse_args()
+    logger = setup_logging("move_it_mirror", cmd_args)
     mirror = MoveItMirror(cmd_args)
 
     try:
         mirror.reload_cfg_file(cmd_args.config_file)
         mirror.run()
     except KeyboardInterrupt:
-        LOGGER.debug("Interrupting")
+        logger.debug("Interrupting")
     finally:
         if mirror.running:
             mirror.chains_stop()

--- a/bin/move_it_server.py
+++ b/bin/move_it_server.py
@@ -86,29 +86,26 @@ For example::
 Logging
 -------
 
-The logging is done on stdout per default. It is however possible to specify a file to log to (instead of stdout) w
-ith the -l or --log option::
+The logging is done on stdout per default. It is however possible to specify a logging config file with the -c
+or --log-config option::
 
-  move_it_server --log /path/to/mylogfile.log myconfig.ini
+  move_it_server --log-config /path/to/mylogconfig.yaml myconfig.ini
 """
-
-import logging.handlers
+from trollmoves.logging import setup_logging
 from trollmoves.server import MoveItServer, parse_args
-
-LOGGER = logging.getLogger("move_it_server")
-LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
 
 
 def main():
     """Start the server."""
     cmd_args = parse_args()
+    logger = setup_logging("move_it_server", cmd_args)
     server = MoveItServer(cmd_args)
 
     try:
         server.reload_cfg_file(cmd_args.config_file)
         server.run()
     except KeyboardInterrupt:
-        LOGGER.debug("Stopping Trollmoves server")
+        logger.debug("Stopping Trollmoves server")
     finally:
         if server.running:
             server.chains_stop()

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -45,6 +45,7 @@ from posttroll.subscriber import Subscriber
 from trollsift.parser import compose
 
 from trollmoves import heartbeat_monitor
+from trollmoves.logging import add_logging_options_to_parser
 from trollmoves.move_it_base import MoveItBase
 from trollmoves.utils import get_local_ips
 from trollmoves.utils import gen_dict_extract, translate_dict
@@ -1006,10 +1007,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("config_file",
                         help="The configuration file to run on.")
-    parser.add_argument("-l", "--log",
-                        help="The file to log to. stdout otherwise.")
-    parser.add_argument("-v", "--verbose", default=False, action="store_true",
-                        help="Toggle verbose logging")
+    add_logging_options_to_parser(parser, legacy=True)
     return parser.parse_args(args)
 
 

--- a/trollmoves/logging.py
+++ b/trollmoves/logging.py
@@ -30,11 +30,10 @@ import yaml
 
 def add_logging_options_to_parser(parser, legacy=False):
     """Add logging options to parser."""
-    if not legacy:
-        parser.add_argument("-c", "--log-config",
-                            help="Log config file to use instead of the standard logging.",
-                            type=pathlib.Path)
-    else:
+    parser.add_argument("-c", "--log-config",
+                        help="Log config file to use instead of the standard logging.",
+                        type=pathlib.Path)
+    if legacy:
         parser.add_argument("-l", "--log",
                             help="The file to log to. stdout otherwise.",
                             type=pathlib.Path,
@@ -55,7 +54,7 @@ class DeprecationWarningAction(argparse.Action):
 def setup_logging(name, cmd_args=None):
     """Set up the logging."""
     with suppress(AttributeError):
-        with open(cmd_args.log_config) as fd:
+        with cmd_args.log_config.open() as fd:
             log_dict = yaml.safe_load(fd.read())
             logging.config.dictConfig(log_dict)
             return logging.getLogger(name)

--- a/trollmoves/logging.py
+++ b/trollmoves/logging.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2022
+#
+# Author(s):
+#
+#   Martin Raspaud <martin.raspaud@smhi.se>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Logging utilities."""
+import argparse
+import logging
+import logging.config
+import os
+import pathlib
+import warnings
+from contextlib import suppress
+
+import yaml
+
+
+def add_logging_options_to_parser(parser, legacy=False):
+    """Add logging options to parser."""
+    if not legacy:
+        parser.add_argument("-c", "--log-config",
+                            help="Log config file to use instead of the standard logging.",
+                            type=pathlib.Path)
+    else:
+        parser.add_argument("-l", "--log",
+                            help="The file to log to. stdout otherwise.",
+                            type=pathlib.Path,
+                            action=DeprecationWarningAction)
+        parser.add_argument("-v", "--verbose", default=False, action=DeprecationWarningAction, const=True, nargs=0,
+                            help="Toggle verbose logging")
+
+
+class DeprecationWarningAction(argparse.Action):
+    """Default action with deprecation warning."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Call the action."""
+        warnings.warn(f"{option_string} is pending deprecation, please use --log-config instead.", RuntimeWarning)
+        setattr(namespace, self.dest, values)
+
+
+def setup_logging(name, cmd_args=None):
+    """Set up the logging."""
+    with suppress(AttributeError):
+        with open(cmd_args.log_config) as fd:
+            log_dict = yaml.safe_load(fd.read())
+            logging.config.dictConfig(log_dict)
+            return logging.getLogger(name)
+    with suppress(AttributeError):
+        setup_legacy_logger(cmd_args)
+        return logging.getLogger(name)
+
+    if cmd_args is None:
+        setup_default_logger()
+        return logging.getLogger(name)
+
+
+def setup_legacy_logger(cmd_args):
+    """Set up the legacy logger."""
+    log_file = cmd_args.log
+    log_level = logging.DEBUG
+    log_dict = {'version': 1,
+                'handlers': {'time_handler': {'class': 'logging.handlers.TimedRotatingFileHandler',
+                                              'filename': os.fspath(log_file),
+                                              'when': 'midnight',
+                                              'backupCount': 7,
+                                              'level': log_level}},
+                'loggers': {'simple_example': {'level': log_level,
+                                               'handlers': ['time_handler'],
+                                               'propagate': False}},
+                'root': {'level': log_level, 'handlers': ['time_handler']}}
+    logging.config.dictConfig(log_dict)
+
+
+def setup_default_logger():
+    """Set up the default logger."""
+    root = logging.getLogger('')
+    handler = logging.StreamHandler()
+    root.addHandler(handler)

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -33,6 +33,7 @@ from posttroll.publisher import get_own_ip
 
 from trollmoves.client import Listener
 from trollmoves.client import request_push
+from trollmoves.logging import add_logging_options_to_parser
 from trollmoves.server import RequestManager, Deleter, AbstractMoveItServer
 from trollmoves.move_it_base import create_publisher
 
@@ -199,14 +200,10 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("config_file",
                         help="The configuration file to run on.")
-    parser.add_argument("-l",
-                        "--log",
-                        help="The file to log to. stdout otherwise.")
     parser.add_argument("-p",
                         "--port",
                         help="The port to publish on. 9010 is the default",
                         default=9010)
-    parser.add_argument("-v", "--verbose", default=False, action="store_true",
-                        help="Toggle verbose logging")
+    add_logging_options_to_parser(parser, legacy=True)
 
     return parser.parse_args(args)

--- a/trollmoves/move_it_base.py
+++ b/trollmoves/move_it_base.py
@@ -36,7 +36,6 @@ import pyinotify
 from posttroll.publisher import Publisher
 
 LOGGER = logging.getLogger("move_it_base")
-LOG_FORMAT = "[%(asctime)s %(levelname)-8s %(name)s] %(message)s"
 
 
 class MoveItBase(ABC):
@@ -50,7 +49,6 @@ class MoveItBase(ABC):
         self.watchman = None
         self.publisher = publisher
         self.chains = {}
-        self.setup_logging()
         LOGGER.info("Starting up.")
         self.setup_watchers()
         self.run_lock = Lock()
@@ -87,28 +85,6 @@ class MoveItBase(ABC):
                                      cmd_filename=self.cmd_args.config_file)
         self.notifier = pyinotify.ThreadedNotifier(self.watchman, event_handler)
         self.watchman.add_watch(os.path.dirname(self.cmd_args.config_file), mask)
-
-    def setup_logging(self):
-        """Set up logging."""
-        global LOGGER
-        LOGGER = logging.getLogger('')
-        if self.cmd_args.verbose:
-            LOGGER.setLevel(logging.DEBUG)
-
-        if self.cmd_args.log:
-            fh_ = logging.handlers.TimedRotatingFileHandler(
-                os.path.join(self.cmd_args.log),
-                "midnight",
-                backupCount=7)
-        else:
-            fh_ = logging.StreamHandler()
-
-        formatter = logging.Formatter(LOG_FORMAT)
-        fh_.setFormatter(formatter)
-
-        LOGGER.addHandler(fh_)
-        LOGGER = logging.getLogger(self.name)
-        pyinotify.log.handlers = [fh_]
 
     def run(self):
         """Start the transfer chains."""

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -55,6 +55,7 @@ from trollmoves.movers import move_it
 from trollmoves.utils import (clean_url, gen_dict_contains, gen_dict_extract,
                               is_file_local)
 from trollmoves.move_it_base import MoveItBase, create_publisher, EventHandler
+from trollmoves.logging import add_logging_options_to_parser
 
 LOGGER = logging.getLogger(__name__)
 
@@ -942,17 +943,13 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("config_file",
                         help="The configuration file to run on.")
-    parser.add_argument("-l", "--log",
-                        help="The file to log to. stdout otherwise.")
     parser.add_argument("-p", "--port",
                         help="The port to publish on. 9010 is the default",
                         default=9010)
-    parser.add_argument("-v", "--verbose", default=False, action="store_true",
-                        help="Toggle verbose logging")
     parser.add_argument("--disable-backlog",
                         help="Disable glob and handling of backlog of files at start/restart",
                         action='store_true')
     parser.add_argument("-w", "--watchdog", default=False, action="store_true",
                         help="Use Watchdog instead of inotify")
-
+    add_logging_options_to_parser(parser, legacy=True)
     return parser.parse_args(args)

--- a/trollmoves/tests/test_logging.py
+++ b/trollmoves/tests/test_logging.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2022
+#
+# Author(s):
+#
+#   Martin Raspaud <martin.raspaud@smhi.se>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for logging utilities."""
+import argparse
+import logging
+import logging.handlers
+import os
+
+import pytest
+
+from trollmoves.logging import add_logging_options_to_parser, setup_logging
+
+log_config = """version: 1
+handlers:
+  null_handler:
+    class: logging.NullHandler
+    level: DEBUG
+loggers:
+  simple_example:
+    level: DEBUG
+    handlers: [null_handler]
+    propagate: no
+root:
+  level: DEBUG
+  handlers: [null_handler]
+"""
+
+
+def test_logging_options_are_added(tmp_path):
+    """Test that logging options are added to the parser."""
+    config_file = os.fspath(tmp_path / "my_log_config")
+    with open(config_file, "w") as fd:
+        fd.write(log_config)
+    cmd_args = _create_arg_parser(config_file)
+    assert os.path.basename(cmd_args.log_config) == "my_log_config"
+
+
+def _create_arg_parser(filename):
+    parser = argparse.ArgumentParser()
+    add_logging_options_to_parser(parser)
+    args = ["-c", filename]
+    cmd_args = parser.parse_args(args)
+    return cmd_args
+
+
+def test_logging_without_options_creates_a_stream_handler():
+    """Test that logging without options creates a stream handler."""
+    logger = setup_logging("my_logger")
+    assert any(isinstance(handler, logging.StreamHandler)
+               for handler in logger.handlers + logger.parent.handlers)
+
+
+def test_logger_has_right_name():
+    """Test that the logger has the provided name."""
+    logger = setup_logging("some_logger")
+    assert logger.name == "some_logger"
+
+
+def test_logger_with_options_applies_config(tmp_path):
+    """Test that logger with options applies the passed config."""
+    handlers = logging.getLogger("").handlers.copy()
+    config_file = os.fspath(tmp_path / "my_log_config")
+    logger = logger_from_config_file(config_file)
+
+    handlers = list(set(logger.handlers + logger.parent.handlers) - set(handlers))
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], logging.NullHandler)
+
+
+def logger_from_config_file(config_file):
+    """Create a logger from a config file."""
+    with open(config_file, "w") as fd:
+        fd.write(log_config)
+    cmd_args = _create_arg_parser(config_file)
+    logger = setup_logging("my_logger", cmd_args)
+    return logger
+
+
+def test_unknown_log_config_crashes(tmp_path):
+    """Test that unknown log config crashes."""
+    config_file = os.fspath(tmp_path / "unknown_config")
+    cmd_args = _create_arg_parser(config_file)
+    with pytest.raises(FileNotFoundError):
+        setup_logging("my_logger", cmd_args)
+
+
+def test_legacy_arguments_work():
+    """Test that legacy arguments work."""
+    handlers = logging.getLogger("").handlers.copy()
+    parser = argparse.ArgumentParser()
+    add_logging_options_to_parser(parser, legacy=True)
+    args = ["-l", "somefile", "-v"]
+    cmd_args = parser.parse_args(args)
+    logger = setup_logging("my_logger", cmd_args)
+    handlers = list(set(logger.handlers + logger.parent.handlers) - set(handlers))
+    assert len(handlers) == 1
+    handler = handlers[0]
+    assert isinstance(handler, logging.handlers.TimedRotatingFileHandler)
+    assert handler.backupCount == 7
+    assert handler.when.lower() == "midnight"
+    assert handler.level == logging.DEBUG
+
+
+def test_legacy_arguments_raise_warnings():
+    """Test that legacy arguments raise warnings."""
+    parser = argparse.ArgumentParser()
+    add_logging_options_to_parser(parser, legacy=True)
+    args = ["-l", "somefile"]
+    with pytest.warns(RuntimeWarning, match='deprecation'):
+        parser.parse_args(args)
+    args = ["-v"]
+    with pytest.warns(RuntimeWarning, match='deprecation'):
+        parser.parse_args(args)


### PR DESCRIPTION
This PR refactors the logging in trollmoves and provides a couple of new functions.
As an asumption, I consider the log config as the way to go in the future and hence issue a deprecation warning when using the old method with -l and -v (although they still work).

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
