### PR TITLE
Add try/except around Message creation

### DIFF
--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -233,23 +233,26 @@ class RequestManager(Thread):
     def _run(self):
         """Run request manager."""
         while self._loop:
+            self._run_loop
+
+    def _run_loop(self):
+        """Run request manager loop."""
+        try:
+            socks = dict(self._poller.poll(timeout=2000))
+        except ZMQError:
+            LOGGER.info("Poller interrupted.")
+            return
+        if socks.get(self.out_socket) == POLLIN:
+            address, payload = self._get_address_and_payload()
+            if payload is None:
+                return
             try:
-                socks = dict(self._poller.poll(timeout=2000))
-            except ZMQError:
-                LOGGER.info("Poller interrupted.")
-                continue
-            if socks.get(self.out_socket) == POLLIN:
-                address, payload = self._get_address_and_payload()
-                if payload is None:
-                    continue
-                try:
-                    self._process_request(Message(rawstr=payload), address)
-                except MessageError:
-                    LOGGER.exception("Failed to create message from payload: %s with address %s",
-                                     str(payload), str(address))
-                    pass
-            elif socks.get(self.in_socket) == POLLIN:
-                self.out_socket.send_multipart(self.in_socket.recv_multipart(NOBLOCK))
+                self._process_request(Message(rawstr=payload), address)
+            except MessageError:
+                LOGGER.exception("Failed to create message from payload: %s with address %s",
+                                 str(payload), str(address))
+        elif socks.get(self.in_socket) == POLLIN:
+            self.out_socket.send_multipart(self.in_socket.recv_multipart(NOBLOCK))
 
     def _get_address_and_payload(self):
         address, payload = None, None

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -233,7 +233,7 @@ class RequestManager(Thread):
     def _run(self):
         """Run request manager."""
         while self._loop:
-            self._run_loop
+            self._run_loop()
 
     def _run_loop(self):
         """Run request manager loop."""

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -45,7 +45,7 @@ from zmq import NOBLOCK, POLLIN, PULL, PUSH, ROUTER, Poller, ZMQError
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers.polling import PollingObserver
 from posttroll import get_context
-from posttroll.message import Message
+from posttroll.message import Message, MessageError
 from posttroll.publisher import get_own_ip
 from posttroll.subscriber import Subscribe
 from trollsift import globify, parse
@@ -242,7 +242,12 @@ class RequestManager(Thread):
                 address, payload = self._get_address_and_payload()
                 if payload is None:
                     continue
-                self._process_request(Message(rawstr=payload), address)
+                try:
+                    self._process_request(Message(rawstr=payload), address)
+                except MessageError:
+                    LOGGER.exception("Failed to create message from payload: %s with address %s",
+                                     str(payload), str(address))
+                    pass
             elif socks.get(self.in_socket) == POLLIN:
                 self.out_socket.send_multipart(self.in_socket.recv_multipart(NOBLOCK))
 

--- a/trollmoves/tests/conftest.py
+++ b/trollmoves/tests/conftest.py
@@ -1,0 +1,15 @@
+"""The conftest module to set up pytest."""
+
+
+def pytest_collection_modifyitems(items):
+    """Modifiy test items in place to ensure test modules run in a given order."""
+    MODULE_ORDER = ["test_logging"]
+    module_mapping = {item: item.module.__name__ for item in items}
+
+    sorted_items = items.copy()
+    # Iteratively move tests of each module to the end of the test queue
+    for module in MODULE_ORDER:
+        sorted_items = [it for it in sorted_items if module_mapping[it] != module] + [
+            it for it in sorted_items if module_mapping[it] == module
+        ]
+    items[:] = sorted_items

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -224,3 +224,44 @@ class TestMoveItServer:
             client = MoveItServer(cmd_args)
             client.signal_reload_cfg_file()
             mock_reload_config.assert_called_once()
+
+@patch("trollmoves.server.get_context")
+@patch("trollmoves.server.Poller.poll")
+@patch("trollmoves.server.RequestManager._set_station")
+@patch("trollmoves.server.RequestManager._set_out_socket")
+@patch("trollmoves.server.RequestManager._get_address_and_payload")
+@patch("trollmoves.server.RequestManager._validate_file_pattern")
+def test_requestmanager_run_valid_pytroll_message(patch_validate_file_pattern, patch_get_address_and_payload, patch_set_out_socket, patch_set_station, patch_poller, patch_get_context, caplog):
+    """Test request manager run with valid address and payload."""
+    from zmq import POLLIN
+    from trollmoves.server import RequestManager
+    from posttroll.message import _MAGICK
+    payload = (_MAGICK +
+               r'/test/1/2/3 info ras@hawaii 2008-04-11T22:13:22.123000 v1.01' +
+               r' text/ascii "what' + r"'" + r's up doc"')
+    address = b'tcp://192.168.10.8:37325'
+    patch_get_address_and_payload.return_value = address, payload
+    port = 9876
+    patch_poller.return_value = {'POLLIN': POLLIN}
+    req_man = RequestManager(port)
+    req_man.out_socket = 'POLLIN'
+    req_man._run_loop()
+    assert caplog.text in ''
+
+@patch("trollmoves.server.get_context")
+@patch("trollmoves.server.Poller.poll")
+@patch("trollmoves.server.RequestManager._set_station")
+@patch("trollmoves.server.RequestManager._set_out_socket")
+@patch("trollmoves.server.RequestManager._get_address_and_payload")
+@patch("trollmoves.server.RequestManager._validate_file_pattern")
+def test_requestmanager_run_MessageError_exception(patch_validate_file_pattern, patch_get_address_and_payload, patch_set_out_socket, patch_set_station, patch_poller, patch_get_context, caplog):
+    """Test request manager run with invalid payload causing a MessageError exception."""
+    from zmq import POLLIN
+    from trollmoves.server import RequestManager
+    patch_get_address_and_payload.return_value = "address", "fake_payload"
+    port = 9876
+    patch_poller.return_value = {'POLLIN': POLLIN}
+    req_man = RequestManager(port)
+    req_man.out_socket = 'POLLIN'
+    req_man._run_loop()
+    assert "Failed to create message from payload: fake_payload with address address" in caplog.text

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -232,13 +232,14 @@ class TestMoveItServer:
 @patch("trollmoves.server.RequestManager._set_out_socket")
 @patch("trollmoves.server.RequestManager._get_address_and_payload")
 @patch("trollmoves.server.RequestManager._validate_file_pattern")
-def test_requestmanager_run_valid_pytroll_message(patch_validate_file_pattern,
+@patch("trollmoves.server.RequestManager._process_request")
+def test_requestmanager_run_valid_pytroll_message(patch_process_request,
+                                                  patch_validate_file_pattern,
                                                   patch_get_address_and_payload,
                                                   patch_set_out_socket,
                                                   patch_set_station,
                                                   patch_poller,
-                                                  patch_get_context,
-                                                  caplog):
+                                                  patch_get_context):
     """Test request manager run with valid address and payload."""
     from zmq import POLLIN
     from trollmoves.server import RequestManager
@@ -253,7 +254,7 @@ def test_requestmanager_run_valid_pytroll_message(patch_validate_file_pattern,
     req_man = RequestManager(port)
     req_man.out_socket = 'POLLIN'
     req_man._run_loop()
-    assert caplog.text in ''
+    patch_process_request.assert_called_once()
 
 
 @patch("trollmoves.server.get_context")
@@ -272,10 +273,12 @@ def test_requestmanager_run_MessageError_exception(patch_validate_file_pattern,
     """Test request manager run with invalid payload causing a MessageError exception."""
     from zmq import POLLIN
     from trollmoves.server import RequestManager
+    import logging
     patch_get_address_and_payload.return_value = "address", "fake_payload"
     port = 9876
     patch_poller.return_value = {'POLLIN': POLLIN}
     req_man = RequestManager(port)
     req_man.out_socket = 'POLLIN'
-    req_man._run_loop()
+    with caplog.at_level(logging.DEBUG):
+        req_man._run_loop()
     assert "Failed to create message from payload: fake_payload with address address" in caplog.text

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -231,7 +231,13 @@ class TestMoveItServer:
 @patch("trollmoves.server.RequestManager._set_out_socket")
 @patch("trollmoves.server.RequestManager._get_address_and_payload")
 @patch("trollmoves.server.RequestManager._validate_file_pattern")
-def test_requestmanager_run_valid_pytroll_message(patch_validate_file_pattern, patch_get_address_and_payload, patch_set_out_socket, patch_set_station, patch_poller, patch_get_context, caplog):
+def test_requestmanager_run_valid_pytroll_message(patch_validate_file_pattern,
+                                                  patch_get_address_and_payload,
+                                                  patch_set_out_socket,
+                                                  patch_set_station,
+                                                  patch_poller,
+                                                  patch_get_context,
+                                                  caplog):
     """Test request manager run with valid address and payload."""
     from zmq import POLLIN
     from trollmoves.server import RequestManager
@@ -254,7 +260,13 @@ def test_requestmanager_run_valid_pytroll_message(patch_validate_file_pattern, p
 @patch("trollmoves.server.RequestManager._set_out_socket")
 @patch("trollmoves.server.RequestManager._get_address_and_payload")
 @patch("trollmoves.server.RequestManager._validate_file_pattern")
-def test_requestmanager_run_MessageError_exception(patch_validate_file_pattern, patch_get_address_and_payload, patch_set_out_socket, patch_set_station, patch_poller, patch_get_context, caplog):
+def test_requestmanager_run_MessageError_exception(patch_validate_file_pattern,
+                                                   patch_get_address_and_payload,
+                                                   patch_set_out_socket,
+                                                   patch_set_station,
+                                                   patch_poller,
+                                                   patch_get_context,
+                                                   caplog):
     """Test request manager run with invalid payload causing a MessageError exception."""
     from zmq import POLLIN
     from trollmoves.server import RequestManager


### PR DESCRIPTION
Add try/except around Message creation in request manager loop.

This to avoid the request manager loop to crash if it get an invalid message.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
