### PR TITLE
Do not transform local paths to ssh-uris

### DIFF
--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -491,7 +491,7 @@ def make_uris(msg, destination, login=None):
     """Create local URIs for the received files."""
     duri = urlparse(destination)
     scheme = duri.scheme
-    netloc = duri.netloc  # local file
+    netloc = duri.netloc
     if scheme != "s3" and duri.hostname and is_localhost(duri.hostname):
         scheme = ""
         netloc = ""

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -933,7 +933,6 @@ class PushRequester:
     def connect(self):
         """Connect to the server."""
         self._socket = get_context().socket(REQ)
-        # self._socket.setsockopt(zmq.RCVTIMEO, 500)  # milliseconds
         self._socket.connect(self._reqaddress)
         self._poller.register(self._socket, POLLIN)
 

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -495,7 +495,7 @@ def make_uris(msg, destination, login=None):
     if scheme != "s3" and duri.hostname and is_localhost(duri.hostname):
         scheme = ""
         netloc = ""
-    elif login:
+    elif login and netloc:
         # Add (only) user to uri.
         netloc = login.split(":")[0] + "@" + netloc
 

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -492,7 +492,10 @@ def make_uris(msg, destination, login=None):
     duri = urlparse(destination)
     scheme = duri.scheme
     netloc = duri.netloc  # local file
-    if login:
+    if scheme != "s3" and duri.hostname and is_localhost(duri.hostname):
+        scheme = ""
+        netloc = ""
+    elif login:
         # Add (only) user to uri.
         netloc = login.split(":")[0] + "@" + netloc
 

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -492,12 +492,13 @@ def make_uris(msg, destination, login=None):
     duri = urlparse(destination)
     scheme = duri.scheme
     netloc = duri.netloc
-    if scheme != "s3" and duri.hostname and is_localhost(duri.hostname):
+    if scheme != "s3" and empty_or_localhost(duri.hostname):
         scheme = ""
         netloc = ""
-    elif login and netloc:
-        # Add (only) user to uri.
-        netloc = login.split(":")[0] + "@" + netloc
+    elif netloc:
+        if login:
+            # Add (only) user to uri.
+            netloc = login.split(":")[0] + "@" + netloc
 
     def uri_callback(var):
         uid = var['uid']
@@ -506,6 +507,11 @@ def make_uris(msg, destination, login=None):
         return var
     msg.data = translate_dict(msg.data, ('uri', 'uid'), uri_callback)
     return msg
+
+
+def empty_or_localhost(hostname):
+    """Check that hostname is either empty or referring to localhost."""
+    return ((not hostname) or (hostname and is_localhost(hostname)))
 
 
 def replace_mda(msg, kwargs):

--- a/trollmoves/logging.py
+++ b/trollmoves/logging.py
@@ -58,13 +58,12 @@ def setup_logging(name, cmd_args=None):
             log_dict = yaml.safe_load(fd.read())
             logging.config.dictConfig(log_dict)
             return logging.getLogger(name)
-    with suppress(AttributeError):
+    with suppress(AttributeError, TypeError):
         setup_legacy_logger(cmd_args)
         return logging.getLogger(name)
 
-    if cmd_args is None:
-        setup_default_logger()
-        return logging.getLogger(name)
+    setup_default_logger()
+    return logging.getLogger(name)
 
 
 def setup_legacy_logger(cmd_args):

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -1578,13 +1578,13 @@ def test_create_local_dir_s3():
 
 
 @pytest.mark.parametrize("destination",
-                         ["file://localhost/directory",
-                          "/localhost/directory"])
+                         ["file://localhost/some/directory",
+                          "/some/directory"])
 def test_make_uris_local_destination(destination):
     """Test that the published messages are formulated correctly for local destinations."""
     from trollmoves.client import make_uris
 
-    expected_uri = os.path.join(destination, "file1.png")
+    expected_uri = os.path.join("/some/directory", "file1.png")
     msg = make_uris(MSG_FILE, destination)
     assert msg.data['uri'] == expected_uri
 
@@ -1614,6 +1614,18 @@ def test_make_uris_remote_destination_with_login():
     msg = make_uris(MSG_FILE, destination, login=login)
     assert msg.data['uri'] == expected_uri
     assert password not in msg.data['uri']
+
+
+def test_make_uris_local_destination_with_ftp():
+    """Test that the published messages are formulated correctly for local destinations provided with scheme."""
+    from trollmoves.client import make_uris
+    import socket
+
+    local_directory = "/san1/polar_in/regional/osisaf"
+    destination = "ftp://" + socket.gethostname() + local_directory
+    expected_uri = os.path.join(local_directory, "file1.png")
+    msg = make_uris(MSG_FILE, destination)
+    assert msg.data['uri'] == expected_uri
 
 
 def test_make_uris_s3_destination():

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -1582,7 +1582,17 @@ def test_make_uris_local_destination():
     from trollmoves.client import make_uris
 
     destination = "file://localhost/directory"
-    expected_uri = os.path.join(destination, "file1.png").replace("file://", "ssh://")
+    expected_uri = os.path.join(destination, "file1.png")
+    msg = make_uris(MSG_FILE, destination)
+    assert msg.data['uri'] == expected_uri
+
+
+def test_make_uris_local_file():
+    """Test that the published messages are formulated correctly for local destinations."""
+    from trollmoves.client import make_uris
+
+    destination = "/localhost/directory"
+    expected_uri = os.path.join(destination, "file1.png")
     msg = make_uris(MSG_FILE, destination)
     assert msg.data['uri'] == expected_uri
 
@@ -1595,6 +1605,23 @@ def test_make_uris_remote_destination():
     expected_uri = os.path.join(destination, "file1.png")
     msg = make_uris(MSG_FILE, destination)
     assert msg.data['uri'] == expected_uri
+
+
+def test_make_uris_remote_destination_with_login():
+    """Test that the published messages are formulated correctly for remote destinations."""
+    from trollmoves.client import make_uris
+
+    user = "user1"
+    password = "1234bleh"
+    login = f"{user}:{password}"
+    scheme = "ftp://"
+    host = "google.com"
+    directory = "/directory"
+    destination = scheme + host + directory
+    expected_uri = os.path.join(scheme + user + "@" + host + directory, "file1.png")
+    msg = make_uris(MSG_FILE, destination, login=login)
+    assert msg.data['uri'] == expected_uri
+    assert password not in msg.data['uri']
 
 
 def test_make_uris_s3_destination():

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -1702,3 +1702,4 @@ def test_request_push_ftp(send_ack, send_request, clean_ongoing_transfer, file_c
     assert "someuser" not in file_msg.data["uri"]
     assert "somepass" not in file_msg.data["uri"]
     assert "/some/dir" in file_msg.data["uri"]
+    assert not file_msg.data["uri"].startswith("ftp://")

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -1577,21 +1577,13 @@ def test_create_local_dir_s3():
     assert res is None
 
 
-def test_make_uris_local_destination():
+@pytest.mark.parametrize("destination",
+                         ["file://localhost/directory",
+                          "/localhost/directory"])
+def test_make_uris_local_destination(destination):
     """Test that the published messages are formulated correctly for local destinations."""
     from trollmoves.client import make_uris
 
-    destination = "file://localhost/directory"
-    expected_uri = os.path.join(destination, "file1.png")
-    msg = make_uris(MSG_FILE, destination)
-    assert msg.data['uri'] == expected_uri
-
-
-def test_make_uris_local_file():
-    """Test that the published messages are formulated correctly for local destinations."""
-    from trollmoves.client import make_uris
-
-    destination = "/localhost/directory"
     expected_uri = os.path.join(destination, "file1.png")
     msg = make_uris(MSG_FILE, destination)
     assert msg.data['uri'] == expected_uri

--- a/trollmoves/tests/test_client.py
+++ b/trollmoves/tests/test_client.py
@@ -1628,6 +1628,23 @@ def test_make_uris_local_destination_with_ftp():
     assert msg.data['uri'] == expected_uri
 
 
+def test_make_uris_local_destination_with_ftp_and_login():
+    """Test published messages for local destinations provided with scheme and login."""
+    from trollmoves.client import make_uris
+    import socket
+
+    user = "user1"
+    password = "1234bleh"
+    login = f"{user}:{password}"
+    scheme = "ftp://"
+    local_directory = "/san1/polar_in/regional/osisaf"
+    destination = scheme + socket.gethostname() + local_directory
+
+    expected_uri = os.path.join(local_directory, "file1.png")
+    msg = make_uris(MSG_FILE, destination, login=login)
+    assert msg.data['uri'] == expected_uri
+
+
 def test_make_uris_s3_destination():
     """Test that the published messages are formulated correctly for S3 destinations."""
     from trollmoves.client import make_uris


### PR DESCRIPTION
For some reason in the past it was decided that files local to the server should be prefixed with "ssh://someserver" for publishing.
I can see a reason for doing this, and it triggers paramiko down the line in our setup (trollflow2).
So this PR removes this behaviour.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
