### PR TITLE
Add retries to SCPMover.copy()

### DIFF
--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -378,7 +378,7 @@ class ScpMover(Mover):
         _ = self._run_with_retries(self._copy, "SCP copy")
 
     def _copy(self):
-        from scp import SCPError
+        from scp import SCPException
 
         success = False
         try:
@@ -393,7 +393,7 @@ class ScpMover(Mover):
             else:
                 LOGGER.error("OSError in scp.put: %s", str(osex))
                 raise
-        except SCPError as err:
+        except SCPException as err:
             LOGGER.error("SCP failed: %s", str(err))
         except Exception as err:
             LOGGER.error("Something went wrong with scp: %s", str(err))

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -115,8 +115,7 @@ class Mover(object):
     def get_connection(self, hostname, port, username=None):
         """Get the connection."""
         with self.active_connection_lock:
-            LOGGER.debug("Destination username and passwd: %s %s",
-                         self._dest_username, self._dest_password)
+            LOGGER.debug("Destination username: %s", self._dest_username)
             LOGGER.debug('Getting connection to %s@%s:%s',
                          username, hostname, port)
             try:

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -299,7 +299,7 @@ class ScpMover(Mover):
         """Open a connection."""
         retries = 3
 
-        ssh_connection = self._run_with_retries(self._open_connection, num_retries=retries)
+        ssh_connection = self._run_with_retries(self._open_connection, "ssh connect", num_retries=retries)
         if ssh_connection is None:
             raise IOError("Failed to ssh connect after 3 attempts")
         return ssh_connection
@@ -333,14 +333,14 @@ class ScpMover(Mover):
         ssh_connection.close()
         return None
 
-    def _run_with_retries(self, func, num_retries=3):
+    def _run_with_retries(self, func, name, num_retries=3):
         res = None
         for _ in range(num_retries):
             res = func()
             if res:
                 break
         time.sleep(2)
-        LOGGER.debug(f"Retrying {self.__class__.__name__}.{func.__name__}() ...")
+        LOGGER.debug(f"Retrying {name} ...")
 
         return res
 
@@ -372,7 +372,7 @@ class ScpMover(Mover):
     def copy(self):
         """Upload the file."""
         retries = 3
-        _ = self._run_with_retries(self._copy, num_retries=retries)
+        _ = self._run_with_retries(self._copy, "SCP copy", num_retries=retries)
 
     def _copy(self):
         from scp import SCPError

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -296,9 +296,7 @@ class ScpMover(Mover):
 
     def open_connection(self):
         """Open a connection."""
-        retries = 3
-
-        ssh_connection = self._run_with_retries(self._open_connection, "ssh connect", num_retries=retries)
+        ssh_connection = self._run_with_retries(self._open_connection, "ssh connect")
         if ssh_connection is None:
             raise IOError("Failed to ssh connect after 3 attempts")
         return ssh_connection
@@ -338,7 +336,8 @@ class ScpMover(Mover):
                      self._dest_username)
         return ssh_connection
 
-    def _run_with_retries(self, func, name, num_retries=3):
+    def _run_with_retries(self, func, name):
+        num_retries = self.attrs.get("num_ssh_retries", 3)
         res = None
         for _ in range(num_retries):
             res = func()
@@ -376,8 +375,7 @@ class ScpMover(Mover):
 
     def copy(self):
         """Upload the file."""
-        retries = 3
-        _ = self._run_with_retries(self._copy, "SCP copy", num_retries=retries)
+        _ = self._run_with_retries(self._copy, "SCP copy")
 
     def _copy(self):
         from scp import SCPError

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -579,6 +579,7 @@ def _read_ini_config(filename):
         _parse_nameserver(res[section], cp_[section])
         _parse_addresses(res[section])
         _parse_delete(res[section], cp_[section])
+        _parse_ssh_retries(res[section], cp_[section])
         if not _check_origin_and_listen(res, section):
             continue
         if not _check_topic(res, section):
@@ -594,6 +595,7 @@ def _set_config_defaults(conf):
     conf.setdefault("transfer_req_timeout", 10 * DEFAULT_REQ_TIMEOUT)
     conf.setdefault("ssh_key_filename", None)
     conf.setdefault("delete", False)
+    conf.setdefault("num_ssh_retries", 3)
 
 
 def _parse_nameserver(conf, raw_conf):
@@ -615,6 +617,12 @@ def _parse_delete(conf, raw_conf):
     val = raw_conf.getboolean("delete")
     if val is not None:
         conf["delete"] = val
+
+
+def _parse_ssh_retries(conf, raw_conf):
+    val = raw_conf.getint("num_ssh_retries")
+    if val is not None:
+        conf["num_ssh_retries"] = val
 
 
 def _check_origin_and_listen(res, section):

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -300,3 +300,51 @@ def test_requestmanager_is_delete_set_True(patch_validate_file_pattern):
     port = 9876
     req_man = RequestManager(port, attrs={'delete': True})
     assert req_man._is_delete_set() is True
+
+
+CONFIG_MINIMAL = """
+[test]
+origin = foo
+listen = bar
+"""
+CONFIG_NUM_SSH_RETRIES = CONFIG_MINIMAL + """
+num_ssh_retries = 5
+"""
+
+
+def test_config_defaults():
+    """Test that config defaults are set."""
+    from trollmoves.server import read_config
+
+    with NamedTemporaryFile(mode='w') as tmp_file:
+        tmp_file.write(CONFIG_MINIMAL)
+        tmp_file.file.flush()
+
+        config = read_config(tmp_file.name)
+
+        test_section = config["test"]
+        assert "origin" in test_section
+        assert "listen" in test_section
+        assert test_section["working_directory"] is None
+        assert test_section["compression"] is False
+        assert test_section["req_timeout"] == 1
+        assert test_section["transfer_req_timeout"] == 10
+        assert test_section["ssh_key_filename"] is None
+        assert test_section["delete"] is False
+        assert test_section["num_ssh_retries"] == 3
+        assert test_section["nameserver"] is None
+        assert test_section["addresses"] is None
+
+
+def test_config_num_ssh_retries():
+    """Test that config defaults are set."""
+    from trollmoves.server import read_config
+
+    with NamedTemporaryFile(mode='w') as tmp_file:
+        tmp_file.write(CONFIG_NUM_SSH_RETRIES)
+        tmp_file.file.flush()
+
+        config = read_config(tmp_file.name)
+
+        test_section = config["test"]
+        assert test_section["num_ssh_retries"] == 5


### PR DESCRIPTION
This PR adds retries to the `SCPMover.copy()` method. Currently there's only retries in creating the connection.

VERY early work.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
