### PR TITLE
Handle the distapcthing of a dataset (keeping the same filenames)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U codecov pytest pytest-cov pytest-bdd pytest-reraise pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors>=0.13.0 fsspec
+          pip install -U codecov pytest pytest-cov pytest-bdd pytest-reraise pyyaml trollsift posttroll inotify pyinotify paramiko scp watchdog pytroll-collectors>=0.13.0 fsspec s3fs
 
       - name: Install trollmoves
         run: |
@@ -51,4 +51,3 @@ jobs:
           flags: unittests
           file: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
-

--- a/trollmoves/tests/conftest.py
+++ b/trollmoves/tests/conftest.py
@@ -3,7 +3,7 @@
 
 def pytest_collection_modifyitems(items):
     """Modifiy test items in place to ensure test modules run in a given order."""
-    MODULE_ORDER = ["test_logging"]
+    MODULE_ORDER = ["test_logging", "test_s3downloader"]
     module_mapping = {item: item.module.__name__ for item in items}
 
     sorted_items = items.copy()


### PR DESCRIPTION
This PR adds the possibility to dispatch datasets, A dataset is a set of files with uid's and full uri's. It splits the dataset in separate files and dispatch each file using the original file name and all files of the dataset is of course dispatched to the same destination.


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
