### PR TITLE
Make it possible to pass connection-parameters to the S3 mover

### DIFF
--- a/examples/dispatch.yaml
+++ b/examples/dispatch.yaml
@@ -50,3 +50,67 @@ target1:
         - area: omerc_bb
           daylight: '<30'
           coverage: '>50'
+
+target-s3-example1:
+  host: s3://my-fancy-bucket/
+  connection_parameters:
+    client_kwargs:
+      endpoint_url: 'https://minio-server.mydomain.se:9000'
+      verify: false
+    secret: "my-super-secret-key"
+    key: "my-access-key"
+    use_ssl: true
+  aliases:
+    platform_name:
+      Suomi-NPP: npp
+      NOAA-20: j01
+      NOAA-21: j02
+    variant:
+      DR: directreadout
+
+  dispatch_configs:
+    - topics:
+        - /atms/sdr/1
+      conditions:
+        - sensor: [atms, [atms]]
+          format: SDR
+          variant: DR
+      directory: /upload/sdr
+
+target-s3-example2:
+  # In this example we do not expose the secret-key neither the access-key, but
+  # using a user specific config file with path relative to the users home like this:
+  # .aws/config
+  # The content of this file may then look like this:
+  # [default]
+  #
+  # [profile "my-aws-profile"]
+  # aws_access_key_id = <the-actual-access-key-for-the-s3-bucket>
+  # aws_secret_access_key = <the-actual-secret-key-for-the-s3-bucket>
+  #
+  # --- end of file ---
+  # See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file
+  #
+  host: s3://my-fancy-bucket/
+  connection_parameters:
+    profile: my-aws-profile
+    client_kwargs:
+      endpoint_url: 'https://minio-server.mydomain.se:9000'
+      verify: false
+    use_ssl: true
+  aliases:
+    platform_name:
+      Suomi-NPP: npp
+      NOAA-20: j01
+      NOAA-21: j02
+    variant:
+      DR: directreadout
+
+  dispatch_configs:
+    - topics:
+        - /atms/sdr/1
+      conditions:
+        - sensor: [atms, [atms]]
+          format: SDR
+          variant: DR
+      directory: /upload/sdr

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -439,7 +439,7 @@ class S3Mover(Mover):
         """Copy the file to a bucket."""
         if S3FileSystem is None:
             raise ImportError("S3Mover requires 's3fs' to be installed.")
-        s3 = S3FileSystem()
+        s3 = S3FileSystem(**self.attrs)
         destination_file_path = self._get_destination()
         _create_s3_destination_path(s3, destination_file_path)
         s3.put(self.origin, destination_file_path)

--- a/trollmoves/tests/test_dispatcher.py
+++ b/trollmoves/tests/test_dispatcher.py
@@ -37,6 +37,7 @@ from trollmoves.dispatcher import (
     Dispatcher, read_config, check_conditions, dispatch, PublisherReporter
 )
 
+
 test_yaml1 = """
 target1:
   host: ftp://ftp.target1.com
@@ -436,6 +437,7 @@ def dispatcher_creator(tmp_path):
         config_file = tmp_path / "my_config"
         with open(config_file, mode="w") as fd:
             fd.write(config)
+
         return Dispatcher(os.fspath(config_file), messages=["some", "messages"])
 
     return _create_dispatcher

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -25,6 +25,7 @@
 import os
 from unittest.mock import patch
 from urllib.parse import urlunparse
+import yaml
 
 import pytest
 
@@ -32,6 +33,34 @@ ORIGIN = '/path/to/mydata/filename.ext'
 USERNAME = 'username'
 PASSWORD = 'passwd'
 ACCOUNT = None
+
+test_yaml_s3_connection_params = """
+target-s3-example1:
+  host: s3://my-fancy-bucket/
+  connection_parameters:
+    client_kwargs:
+      endpoint_url: 'https://minio-server.mydomain.se:9000'
+      verify: false
+    secret: "my-super-secret-key"
+    key: "my-access-key"
+    use_ssl: true
+  aliases:
+    platform_name:
+      Suomi-NPP: npp
+      NOAA-20: j01
+      NOAA-21: j02
+    variant:
+      DR: directreadout
+
+  dispatch_configs:
+    - topics:
+        - /atms/sdr/1
+      conditions:
+        - sensor: [atms, [atms]]
+          format: SDR
+          variant: DR
+      directory: /upload/sdr
+"""
 
 
 def _get_ftp(destination):
@@ -73,16 +102,35 @@ def test_open_ftp_connection_credentials_in_url():
     ftp.return_value.login.assert_called_once_with('auser', 'apasswd')
 
 
-def _get_s3_mover(origin, destination):
+def _get_s3_mover(origin, destination, **attrs):
     from trollmoves.movers import S3Mover
 
-    return S3Mover(origin, destination)
+    return S3Mover(origin, destination, attrs=attrs)
 
 
 @patch('trollmoves.movers.S3FileSystem')
 def test_s3_copy_file_to_base(S3FileSystem):
     """Test copying to base of S3 bucket."""
     s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/")
+    s3_mover.copy()
+
+    S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/filename.ext")
+
+
+@patch('trollmoves.movers.S3FileSystem')
+def test_s3_copy_file_to_base_using_connection_parameters(S3FileSystem):
+    """Test copying to base of S3 bucket."""
+    # Get the connection parameters:
+    config = yaml.safe_load(test_yaml_s3_connection_params)
+    attrs = config['target-s3-example1']['connection_parameters']
+
+    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/", **attrs)
+    assert s3_mover.attrs['client_kwargs'] == {'endpoint_url': 'https://minio-server.mydomain.se:9000',
+                                               'verify': False}
+    assert s3_mover.attrs['secret'] == 'my-super-secret-key'
+    assert s3_mover.attrs['key'] == 'my-access-key'
+    assert s3_mover.attrs['use_ssl'] is True
+
     s3_mover.copy()
 
     S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/filename.ext")


### PR DESCRIPTION
This PR adds the possible to pass connection parameters when moving files to S3. By doing that it may be possible to specify the endpoint-url and the keys in the yaml file directly or indirectly by keeping those secret keys in a config file using profiles as described https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file

I tried documenting this in the example dispatcher yaml file.


<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
