### PR TITLE
Error in destination path when dispatching to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ Additional required packages:
 Additional required packages:
 - ``s3fs``
 
+Special behaviour on destination filepath when using the S3Mover class:
+
+If the destination prefix (~filepath) has a trailing slash ('/') the original
+filename will be appended (analogous to moving a file from one directory to
+another keeping the same filename).
+
+If the destination prefix does not have a trailing slash the operation will be
+analougus to moving a file from one directory to a new destination changing the
+filename. The new destination filename will be the last part of the provided
+destination follwing the last slash ('/')
+
+
 ## s3downloader
 
 This module is able to download files from a s3 endpoint.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ another keeping the same filename).
 If the destination prefix does not have a trailing slash the operation will be
 analougus to moving a file from one directory to a new destination changing the
 filename. The new destination filename will be the last part of the provided
-destination follwing the last slash ('/')
+destination following the last slash ('/').
 
 
 ## s3downloader

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ filename will be appended (analogous to moving a file from one directory to
 another keeping the same filename).
 
 If the destination prefix does not have a trailing slash the operation will be
-analougus to moving a file from one directory to a new destination changing the
+analogous to moving a file from one directory to a new destination changing the
 filename. The new destination filename will be the last part of the provided
 destination following the last slash ('/').
 

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -420,7 +420,7 @@ class S3Mover(Mover):
 
     The transfer is initiated by Trollmoves Client by having destination that starts with "s3://".
 
-    All the connection configurations and such are done using the `fsspec` configuration system:
+    All the connection configurations and such may be done using the `fsspec` configuration system:
 
     https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration
 
@@ -433,6 +433,27 @@ class S3Mover(Mover):
                 "key": "ACCESSKEY"
             }
         }
+
+    However, using the this procedure may not be useful if having several
+    endpoints/buckets with their own access/secret keys. Instead one can use
+    aws profiles (placed in `.aws/config`) to for instance set the
+    access/secret keys for various endpoints and then keep the actual url of
+    the endpoints in the yaml configuration (see examples/dispatch.yaml).
+
+    See documentation on profiles here:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file
+
+
+    NB! Special behaviour on destination filepath:
+
+    If the destination prefix (~filepath) has a trailing slash ('/') the
+    original filename will be appended (analogous to moving a file from one
+    directory to another keeping the same filename).
+
+    If the destination prefix does not have a trailing slash the operation will
+    be analougus to moving a file from one directory to a new destination
+    changing the filename. The new destination filename will be the last part
+    of the provided destination follwing the last slash ('/').
 
     """
 

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -90,6 +90,7 @@ class Mover(object):
 
     def __init__(self, origin, destination, attrs=None):
         """Initialize the Mover."""
+        LOGGER.debug("destination = %s", str(destination))
         try:
             self.destination = urlparse(destination)
         except AttributeError:
@@ -441,12 +442,16 @@ class S3Mover(Mover):
             raise ImportError("S3Mover requires 's3fs' to be installed.")
         s3 = S3FileSystem()
         destination_file_path = self._get_destination()
+        LOGGER.debug('destination_file_path = %s', destination_file_path)
         _create_s3_destination_path(s3, destination_file_path)
+        LOGGER.debug('Before call to put: destination_file_path = %s', destination_file_path)
+        LOGGER.debug('self.origin = %s', self.origin)
         s3.put(self.origin, destination_file_path)
 
     def _get_destination(self):
         bucket_parts = []
         bucket_parts.append(self.destination.netloc)
+
         if self.destination.path != '/':
             bucket_parts.append(self.destination.path.strip('/'))
         bucket_parts.append(os.path.basename(self.origin))

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -451,7 +451,7 @@ class S3Mover(Mover):
     directory to another keeping the same filename).
 
     If the destination prefix does not have a trailing slash the operation will
-    be analougus to moving a file from one directory to a new destination
+    be analogous to moving a file from one directory to a new destination
     changing the filename. The new destination filename will be the last part
     of the provided destination follwing the last slash ('/').
 

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -454,7 +454,8 @@ class S3Mover(Mover):
 
         if self.destination.path != '/':
             bucket_parts.append(self.destination.path.strip('/'))
-        bucket_parts.append(os.path.basename(self.origin))
+        if self.destination.path.endswith('/'):
+            bucket_parts.append(os.path.basename(self.origin))
 
         return '/'.join(bucket_parts)
 

--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -453,7 +453,7 @@ class S3Mover(Mover):
     If the destination prefix does not have a trailing slash the operation will
     be analogous to moving a file from one directory to a new destination
     changing the filename. The new destination filename will be the last part
-    of the provided destination follwing the last slash ('/').
+    of the provided destination following the last slash ('/').
 
     """
 

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -145,6 +145,7 @@ def test_s3_copy_file_to_prefix_urlparse(S3FileSystem):
     S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/upload/my_satellite_data.h5")
 
 
+@patch('trollmoves.movers.S3FileSystem')
 def test_s3_copy_file_to_base_using_connection_parameters(S3FileSystem):
     """Test copying to base of S3 bucket."""
     # Get the connection parameters:

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -90,27 +90,30 @@ def test_s3_copy_file_to_base(S3FileSystem):
 
 
 @patch('trollmoves.movers.S3FileSystem')
-def test_s3_get_destination_from_string(S3FileSystem):
+def test_s3_copy_file_to_prefix_with_trailing_slash(S3FileSystem):
     """Test get the correct S3-bucket destination filename."""
-    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/")
-    result = s3_mover._get_destination()
-    assert result == 'data-bucket/filename.ext'
-
     s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/upload/")
-    result = s3_mover._get_destination()
-    assert result == 'data-bucket/upload/filename.ext'
+    s3_mover.copy()
 
-    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/upload")
-    result = s3_mover._get_destination()
-    assert result == 'data-bucket/upload'
+    S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/upload/filename.ext")
 
 
 @patch('trollmoves.movers.S3FileSystem')
-def test_s3_get_destination_from_parseresult(S3FileSystem):
+def test_s3_copy_file_to_prefix_no_trailing_slash(S3FileSystem):
+    """Test get the correct S3-bucket destination filename."""
+    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/upload")
+    s3_mover.copy()
+
+    S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/upload")
+
+
+@patch('trollmoves.movers.S3FileSystem')
+def test_s3_copy_file_to_prefix_urlparse_file_with_extention(S3FileSystem):
     """Test get the correct S3-bucket destination filename."""
     s3_mover = _get_s3_mover(ORIGIN, urlparse("s3://data-bucket/upload/my_satellite_data.h5"))
-    result = s3_mover._get_destination()
-    assert result == 'data-bucket/upload//my_satellite_data.h5'
+    s3_mover.copy()
+
+    S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/upload/my_satellite_data.h5")
 
 
 @patch('trollmoves.movers.S3FileSystem')

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -91,7 +91,7 @@ def test_s3_copy_file_to_base(S3FileSystem):
 
 @patch('trollmoves.movers.S3FileSystem')
 def test_s3_copy_file_to_prefix_with_trailing_slash(S3FileSystem):
-    """Test get the correct S3-bucket destination filename."""
+    """Test that when destination ends in a slash, the original file basename is added to it."""
     s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/upload/")
     s3_mover.copy()
 

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -100,7 +100,7 @@ def test_s3_copy_file_to_prefix_with_trailing_slash(S3FileSystem):
 
 @patch('trollmoves.movers.S3FileSystem')
 def test_s3_copy_file_to_prefix_no_trailing_slash(S3FileSystem):
-    """Test get the correct S3-bucket destination filename."""
+    """Test giving destination without trailing slash to see it is used as object name."""
     s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/upload")
     s3_mover.copy()
 

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -108,8 +108,8 @@ def test_s3_copy_file_to_prefix_no_trailing_slash(S3FileSystem):
 
 
 @patch('trollmoves.movers.S3FileSystem')
-def test_s3_copy_file_to_prefix_urlparse_file_with_extention(S3FileSystem):
-    """Test get the correct S3-bucket destination filename."""
+def test_s3_copy_file_to_prefix_urlparse(S3FileSystem):
+    """Test that giving urlparse() result as destination works."""
     s3_mover = _get_s3_mover(ORIGIN, urlparse("s3://data-bucket/upload/my_satellite_data.h5"))
     s3_mover.copy()
 

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -25,6 +25,7 @@
 import os
 from unittest.mock import patch
 from urllib.parse import urlunparse
+from urllib.parse import urlparse
 
 import pytest
 
@@ -86,6 +87,30 @@ def test_s3_copy_file_to_base(S3FileSystem):
     s3_mover.copy()
 
     S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/filename.ext")
+
+
+@patch('trollmoves.movers.S3FileSystem')
+def test_s3_get_destination_from_string(S3FileSystem):
+    """Test get the correct S3-bucket destination filename."""
+    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/")
+    result = s3_mover._get_destination()
+    assert result == 'data-bucket/filename.ext'
+
+    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/upload/")
+    result = s3_mover._get_destination()
+    assert result == 'data-bucket/upload/filename.ext'
+
+    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/upload")
+    result = s3_mover._get_destination()
+    assert result == 'data-bucket/upload'
+
+
+@patch('trollmoves.movers.S3FileSystem')
+def test_s3_get_destination_from_parseresult(S3FileSystem):
+    """Test get the correct S3-bucket destination filename."""
+    s3_mover = _get_s3_mover(ORIGIN, urlparse("s3://data-bucket/upload/my_satellite_data.h5"))
+    result = s3_mover._get_destination()
+    assert result == 'data-bucket/upload//my_satellite_data.h5'
 
 
 @patch('trollmoves.movers.S3FileSystem')


### PR DESCRIPTION
When using the dispatcher to upload files to an S3-bucket the destination path is wrong.

As an example: 

`mover = S3Mover('/path/to/local/file.txt', 's3://atms-dr/target-dir/file.txt')` will result in `s3://atms-dr/target-dir/file.txt/file.txt`



This PR seeks to solve this.


<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
