### PR TITLE
Add the fetcher functionality and documentation on rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,39 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,27 @@
+"""The sphinx configuration."""
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Trollmoves'
+copyright = '2024, Pytroll devs'
+author = 'Pytroll devs'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.napoleon", "sphinx.ext.autodoc"]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ author = 'Pytroll devs'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = ["sphinx.ext.napoleon", "sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
+autodoc_mock_imports = ["fsspec"]
 
 templates_path = ['_templates']
 exclude_patterns = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ author = 'Pytroll devs'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.napoleon", "sphinx.ext.autodoc"]
+extensions = ["sphinx.ext.napoleon", "sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
 
 templates_path = ['_templates']
 exclude_patterns = []
@@ -25,3 +25,8 @@ exclude_patterns = []
 
 html_theme = 'alabaster'
 html_static_path = ['_static']
+
+# intersphinx
+intersphinx_mapping = {
+    "posttroll": ("https://posttroll.readthedocs.io/en/latest/", None),
+}

--- a/docs/source/fetcher.rst
+++ b/docs/source/fetcher.rst
@@ -36,6 +36,12 @@ An example config would be for this command line interface would be::
         nameserver: false
 
 
+The `publisher_config` and `subscriber_config` dictionaries in the config are passed straight to posttroll's
+:py:func:`~posttroll.publisher.create_publisher_from_dict_config` and
+:py:func:`~posttroll.subscriber.create_subscriber_from_dict_config` respectively, so refer to the corresponding
+documentation to see how to populate them.
+
+
 API
 ***
 

--- a/docs/source/fetcher.rst
+++ b/docs/source/fetcher.rst
@@ -8,7 +8,7 @@ Command line script
 *******************
 
 The pytroll-fetcher script listen to posttroll messages and reacts by downloading files to a given locations. The help
-command of the scripts gives::
+command of the script gives::
 
     usage: pytroll-fetcher [-h] [-c LOG_CONFIG] config
 

--- a/docs/source/fetcher.rst
+++ b/docs/source/fetcher.rst
@@ -1,0 +1,43 @@
+Pytroll fetcher
+---------------
+
+The pytroll-fetcher script and trollmoves.fetcher library are tools to fetch (download) files or objects from local or
+remote filesystems.
+
+Command line script
+*******************
+
+The pytroll-fetcher script listen to posttroll messages and reacts by downloading files to a given locations. The help
+command of the scripts gives::
+
+    usage: pytroll-fetcher [-h] [-c LOG_CONFIG] config
+
+    Fetches files/objects advertised as messages.
+
+    positional arguments:
+    config                The yaml config file.
+
+    options:
+    -h, --help            show this help message and exit
+    -c LOG_CONFIG, --log-config LOG_CONFIG
+                            Log config file to use instead of the standard logging.
+
+    Thanks for using pytroll-fetcher!
+
+An example config would be for this command line interface would be::
+
+    destination: /home/myuser/downloads/
+    publisher_config:
+        nameservers: false
+        port: 1979
+    subscriber_config:
+        addresses:
+        - ipc://some_pipe
+        nameserver: false
+
+
+API
+***
+
+.. automodule:: trollmoves.fetcher
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ These include:
    :caption: Contents:
 
    fetcher
+   s3downloader
 
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,31 @@
+.. Trollmoves documentation master file, created by
+   sphinx-quickstart on Tue Apr 23 10:40:44 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Trollmoves's documentation!
+======================================
+
+Trollmoves is a library and set of scripts that can be used to move files between servers and filesystems.
+
+These include:
+  - fetcher
+  - Move_it
+  - Move_it_server and move_it_client
+  - Trollstalker (Pytroll-watchers should be prefered if possible)
+  - S3downloader
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   fetcher
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/s3downloader.rst
+++ b/docs/source/s3downloader.rst
@@ -1,0 +1,8 @@
+S3 Downloader
+-------------
+
+API
+***
+
+.. automodule:: trollmoves.s3downloader
+   :members:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ extras_require = {
         'paramiko',
         'scp',
     ],
-    "remote_fs": ["pytroll-collectors>=0.16.0"],
+    "remote_fs": ["pytroll-collectors>=0.16.0", "fsspec"],
+    "docs": [],
 }
 
 all_extras = []

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,12 @@ setup(name="trollmoves",
                'bin/dispatcher.py',
                'bin/s3downloader.py',
                ],
+      entry_points={
+          'console_scripts': [
+              'pytroll-fetcher = trollmoves.fetcher:cli',
+          ],
+      },
+
       data_files=[],
       packages=['trollmoves'],
       zip_safe=False,

--- a/trollmoves/fetcher.py
+++ b/trollmoves/fetcher.py
@@ -1,0 +1,124 @@
+"""Fetch files from other (remote) filesystems.
+
+An example config would be for the command line interface would be::
+
+    destination: /home/myuser/downloads/
+    publisher_config:
+        nameservers: false
+        port: 1979
+    subscriber_config:
+        addresses:
+        - ipc://some_pipe
+        nameserver: false
+
+"""
+
+import argparse
+import json
+import logging
+import os
+from contextlib import closing
+from pathlib import Path
+
+import fsspec
+import yaml
+from posttroll.publisher import create_publisher_from_dict_config
+from posttroll.subscriber import create_subscriber_from_dict_config
+
+from trollmoves.logging import add_logging_options_to_parser, setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_file(file_to_fetch, download_dir, filesystem=None):
+    """Fetch a file.
+
+    Args:
+        file_to_fetch: The Path of the file to fetch. Can be a UPath form universal_path.
+        download_dir: The directory to download the file to.
+        filesystem: The file system to use if provided. Should be a dictionary that will be fed to fsspec.
+
+    Returns:
+        The Path to the downloaded file.
+
+    Example:
+
+        >>> fetch_file("https://noaa-himawari8.s3.amazonaws.com/AHI-L1b-FLDK/2017/02/02/0020/HS_H08_20170202_0020_B01_FLDK_R10_S0101.DAT.bz2", "/tmp/")
+        ... # HS_H08_20170202_0020_B01_FLDK_R10_S0101.DAT.bz2 is now present in /tmp/
+
+
+    """  # noqa
+    download_dir = Path(download_dir)
+
+    if filesystem:
+        downloaded_file = _fetch_from_filesystem(file_to_fetch, download_dir, filesystem)
+    else:
+        downloaded_file = _fetch_from_uri(file_to_fetch, download_dir)
+    logger.info(f"Fetched {str(downloaded_file)}")
+    return downloaded_file
+
+
+def _fetch_from_uri(file_to_fetch, download_dir):
+    """Fetch a file from a uri."""
+    fs_file = fsspec.open(file_to_fetch)
+    filesystem = fs_file.fs
+    basename = os.path.basename(fs_file.path)
+    downloaded_file = download_dir / basename
+    filesystem.get_file(fs_file.path, download_dir / basename)
+    return downloaded_file
+
+
+def _fetch_from_filesystem(path_to_fetch, download_dir, fs):
+    """Fetch a file from a path and a filesystem specification."""
+    filesystem = fsspec.AbstractFileSystem.from_json(json.dumps(fs))
+    basename = os.path.basename(path_to_fetch)
+    downloaded_file = download_dir / basename
+    filesystem.get_file(path_to_fetch, download_dir / basename)
+    return downloaded_file
+
+
+def fetch_from_message(message, destination):
+    """Fetch a file provided in a message."""
+    try:
+        return fetch_file(message.data["path"], destination, message.data["filesystem"])
+    except KeyError:
+        return fetch_file(message.data["uri"], destination)
+
+
+def fetch_from_subscriber(destination, subscriber_config, publisher_config):
+    """Fetch files published using a subscriber."""
+    destination = Path(destination)
+
+    pub = create_publisher_from_dict_config(publisher_config)
+    pub.start()
+    with closing(pub):
+        sub = create_subscriber_from_dict_config(subscriber_config)
+        with closing(sub):
+            for message in sub.recv():
+                if message.type != "file":
+                    continue
+                downloaded_file = fetch_from_message(message, destination)
+                message.data.pop("filesystem", None)
+                message.data.pop("path", None)
+                message.data["uri"] = downloaded_file.as_uri()
+                pub.send(str(message))
+
+
+def cli(args=None):
+    """Command line argument for fetching published files."""
+    parser = argparse.ArgumentParser(prog="pytroll-fetcher",
+                                     description="Fetches files/objects advertised as messages.",
+                                     epilog="Thanks for using pytroll-fetcher!")
+
+    parser.add_argument("config", type=str, help="The yaml config file.")
+    add_logging_options_to_parser(parser)
+
+    parsed = parser.parse_args(args)
+
+    setup_logging("pytroll-fetcher", parsed)
+
+    config_file = parsed.config
+    with open(config_file) as fd:
+        config_dict = yaml.safe_load(fd.read())
+
+    return fetch_from_subscriber(**config_dict)

--- a/trollmoves/fetcher.py
+++ b/trollmoves/fetcher.py
@@ -1,17 +1,4 @@
-"""Fetch files from other (remote) filesystems.
-
-An example config would be for the command line interface would be::
-
-    destination: /home/myuser/downloads/
-    publisher_config:
-        nameservers: false
-        port: 1979
-    subscriber_config:
-        addresses:
-        - ipc://some_pipe
-        nameserver: false
-
-"""
+"""Fetch files from other (remote) filesystems."""
 
 import argparse
 import json
@@ -78,7 +65,15 @@ def _fetch_from_filesystem(path_to_fetch, download_dir, fs):
 
 
 def fetch_from_message(message, destination):
-    """Fetch a file provided in a message."""
+    """Fetch a file provided in a message.
+
+    Args:
+        message: A posttroll message instance with information about the files to fetch.
+        destination: the directory to save the files to.
+
+    Returns:
+        The path to the downloaded file.
+    """
     try:
         return fetch_file(message.data["path"], destination, message.data["filesystem"])
     except KeyError:
@@ -86,7 +81,19 @@ def fetch_from_message(message, destination):
 
 
 def fetch_from_subscriber(destination, subscriber_config, publisher_config):
-    """Fetch files published using a subscriber."""
+    """Fetch files published using a subscriber.
+
+    Warning:
+        At the moment, messages that are not of type `file` will be ignored.
+
+    Args:
+        destination: the directory to save the files to.
+        subscriber_config: the settings for the subscriber. Will be passed on as is to posttroll's
+            :py:func:`create_subscriber_from_dict_config`
+        publisher_config: the settings for the publisher. Will be passed on as is to posttroll's
+            :py:func:`create_publisher_from_dict_config`
+
+    """  # noqa
     destination = Path(destination)
 
     pub = create_publisher_from_dict_config(publisher_config)

--- a/trollmoves/fetcher.py
+++ b/trollmoves/fetcher.py
@@ -89,9 +89,9 @@ def fetch_from_subscriber(destination, subscriber_config, publisher_config):
     Args:
         destination: the directory to save the files to.
         subscriber_config: the settings for the subscriber. Will be passed on as is to posttroll's
-            :py:func:`create_subscriber_from_dict_config`
+            :py:func:`~posttroll.subscriber.create_subscriber_from_dict_config`
         publisher_config: the settings for the publisher. Will be passed on as is to posttroll's
-            :py:func:`create_publisher_from_dict_config`
+            :py:func:`~posttroll.publisher.create_publisher_from_dict_config`
 
     """  # noqa
     destination = Path(destination)

--- a/trollmoves/tests/conftest.py
+++ b/trollmoves/tests/conftest.py
@@ -3,7 +3,7 @@
 
 def pytest_collection_modifyitems(items):
     """Modifiy test items in place to ensure test modules run in a given order."""
-    MODULE_ORDER = ["test_logging", "test_s3downloader"]
+    MODULE_ORDER = ["test_fetcher", "test_logging", "test_s3downloader"]
     module_mapping = {item: item.module.__name__ for item in items}
 
     sorted_items = items.copy()

--- a/trollmoves/tests/test_fetcher.py
+++ b/trollmoves/tests/test_fetcher.py
@@ -5,6 +5,7 @@ import logging
 from zipfile import ZipFile
 
 import fsspec
+import yaml
 from posttroll.message import Message
 from posttroll.testing import patched_publisher, patched_subscriber_recv
 
@@ -125,15 +126,11 @@ def test_fetch_message_with_filesystem(tmp_path):
 def test_fetch_message_with_uri(tmp_path):
     """Test fetch_message can use uri."""
     uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
-
+    sdr_file = tmp_path / "sdr" / uid
+    create_data_file(sdr_file)
     msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
            'application/json {"sensor": "viirs", '
-           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}"' '}')
-
-    sdr = tmp_path / "sdr"
-    sdr.mkdir()
-    with open(sdr / uid, "w") as fd:
-        fd.write("viirs data")
+           f'"uid": "{uid}", "uri": "file://{str(sdr_file)}"' '}')
 
     dest_path2 = tmp_path / "dest2"
     dest_path2.mkdir()
@@ -147,15 +144,11 @@ def test_fetch_message_logs(tmp_path, caplog):
     caplog.set_level("INFO")
 
     uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
-
+    sdr_file = tmp_path / "sdr" / uid
+    create_data_file(sdr_file)
     msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
            'application/json {"sensor": "viirs", '
-           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}"' '}')
-
-    sdr = tmp_path / "sdr"
-    sdr.mkdir()
-    with open(sdr / uid, "w") as fd:
-        fd.write("viirs data")
+           f'"uid": "{uid}", "uri": "file://{str(sdr_file)}"' '}')
 
     dest_path2 = tmp_path / "dest2"
     dest_path2.mkdir()
@@ -167,16 +160,13 @@ def test_fetch_message_logs(tmp_path, caplog):
 def test_subscribe_and_fetch(tmp_path):
     """Test subscribe and fetch."""
     uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+    sdr_file = tmp_path / "sdr" / uid
+    create_data_file(sdr_file)
 
     msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
            'application/json {"sensor": "viirs", '
-           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           f'"uid": "{uid}", "uri": "file://{str(sdr_file)}", "path": "{str(sdr_file)}", '
            '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
-
-    sdr = tmp_path / "sdr"
-    sdr.mkdir()
-    with open(sdr / uid, "w") as fd:
-        fd.write("viirs data")
 
     dest_path2 = tmp_path / "dest2"
     dest_path2.mkdir()
@@ -201,32 +191,19 @@ def test_fetcher_cli(tmp_path):
     """Test the fetcher command-line interface."""
     config_file = tmp_path / "config.yaml"
     destination = tmp_path / "destination"
-    destination.mkdir()
-    subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
-    publisher_settings = dict(nameservers=False, port=1979)
-    config = dict(destination=str(destination),
-                  subscriber_config=subscriber_settings,
-                  publisher_config=publisher_settings)
-
-    import yaml
-    with open(config_file, "w") as fd:
-        fd.write(yaml.dump(config))
+    create_config_file(destination, config_file)
 
     uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+    sdr_file = tmp_path / "sdr" / uid
+    create_data_file(sdr_file)
 
     msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
            'application/json {"sensor": "viirs", '
-           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           f'"uid": "{uid}", "uri": "file://{str(sdr_file)}", "path": "{str(sdr_file)}", '
            '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
-
-    sdr = tmp_path / "sdr"
-    sdr.mkdir()
-    with open(sdr / uid, "w") as fd:
-        fd.write("viirs data")
 
     with patched_publisher() as messages:
         with patched_subscriber_recv([Message(rawstr=msg)]):
-
             from trollmoves.fetcher import cli
             cli([str(config_file)])
 
@@ -243,28 +220,16 @@ def test_fetcher_does_not_try_to_fetch_non_file_messages(tmp_path):
     """Test fetcher does not try to fetch non-file messages."""
     config_file = tmp_path / "config.yaml"
     destination = tmp_path / "destination"
-    destination.mkdir()
-    subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
-    publisher_settings = dict(nameservers=False, port=1979)
-    config = dict(destination=str(destination),
-                  subscriber_config=subscriber_settings,
-                  publisher_config=publisher_settings)
-
-    import yaml
-    with open(config_file, "w") as fd:
-        fd.write(yaml.dump(config))
+    create_config_file(destination, config_file)
 
     uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+    sdr_file = tmp_path / "sdr" / uid
+    create_data_file(sdr_file)
 
     msg = ('pytroll://segment/viirs/l1b/ info a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
            'application/json {"sensor": "viirs", '
-           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           f'"uid": "{uid}", "uri": "file://{str(sdr_file)}", "path": "{str(sdr_file)}", '
            '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
-
-    sdr = tmp_path / "sdr"
-    sdr.mkdir()
-    with open(sdr / uid, "w") as fd:
-        fd.write("viirs data")
 
     with patched_publisher() as messages:
         with patched_subscriber_recv([Message(rawstr=msg)]):
@@ -280,31 +245,56 @@ def test_fetcher_uses_log_config(tmp_path):
     """Test fetcher uses log config."""
     config_file = tmp_path / "config.yaml"
     destination = tmp_path / "destination"
+    create_config_file(destination, config_file)
+
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+    sdr_file = tmp_path / "sdr" / uid
+    create_data_file(sdr_file)
+
+    msg = ('pytroll://segment/viirs/l1b/ info a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(sdr_file)}", "path": "{str(sdr_file)}", '
+           '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
+
+    log_config_file = tmp_path / "log_config.yaml"
+    handler_name = "console123"
+    create_log_config(log_config_file, handler_name)
+
+    with patched_publisher():
+        with patched_subscriber_recv([Message(rawstr=msg)]):
+
+            from trollmoves.fetcher import cli
+            cli([str(config_file), "-c", str(log_config_file)])
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    assert root.handlers[0].name == handler_name
+
+
+def create_config_file(destination, config_file):
+    """Create a configuration file."""
     destination.mkdir()
     subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
     publisher_settings = dict(nameservers=False, port=1979)
     config = dict(destination=str(destination),
                   subscriber_config=subscriber_settings,
                   publisher_config=publisher_settings)
-
-    import yaml
     with open(config_file, "w") as fd:
         fd.write(yaml.dump(config))
 
-    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+    return config
 
-    msg = ('pytroll://segment/viirs/l1b/ info a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
-           'application/json {"sensor": "viirs", '
-           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
-           '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
 
-    sdr = tmp_path / "sdr"
-    sdr.mkdir()
-    with open(sdr / uid, "w") as fd:
-        fd.write("viirs data")
+def create_data_file(path):
+    """Create a data file."""
+    path.parent.mkdir()
 
-    log_config_file = tmp_path / "log_config.yaml"
-    handler_name = "console123"
+    with open(path, "w") as fd:
+        fd.write("data")
+
+
+def create_log_config(log_config_file, handler_name):
+    """Create a log config file."""
     log_config = {
         "version": 1,
         "handlers": {
@@ -322,13 +312,3 @@ def test_fetcher_uses_log_config(tmp_path):
     }
     with open(log_config_file, "w") as fd:
         fd.write(yaml.dump(log_config))
-
-    with patched_publisher():
-        with patched_subscriber_recv([Message(rawstr=msg)]):
-
-            from trollmoves.fetcher import cli
-            cli([str(config_file), "-c", str(log_config_file)])
-
-    root = logging.getLogger()
-    assert len(root.handlers) == 1
-    assert root.handlers[0].name == handler_name

--- a/trollmoves/tests/test_fetcher.py
+++ b/trollmoves/tests/test_fetcher.py
@@ -1,0 +1,334 @@
+"""Tests for the fetcher."""
+
+import json
+import logging
+from zipfile import ZipFile
+
+import fsspec
+from posttroll.message import Message
+from posttroll.testing import patched_publisher, patched_subscriber_recv
+
+from trollmoves.fetcher import (fetch_file, fetch_from_message,
+                                fetch_from_subscriber)
+
+
+def test_fetcher_with_simple_uri(tmp_path):
+    """Test fetcher with a simple uri."""
+    filename = "important_data.nc"
+    test_file = tmp_path / filename
+    download_dir = tmp_path / "downloaded"
+    download_dir.mkdir()
+    with open(test_file, "w") as fd:
+        fd.write("very importand data.")
+    uri = test_file.as_uri()
+    fetch_file(uri, str(download_dir))
+    assert (download_dir / filename).exists()
+
+
+def test_fetcher_with_complex_uri(tmp_path):
+    """Test fetcher with a complex uri."""
+    filename = "important_data.nc"
+    test_file = tmp_path / filename
+    download_dir = tmp_path / "downloaded"
+    download_dir.mkdir()
+    with open(test_file, "w") as fd:
+        fd.write("very importand data.")
+    uri = "simplecache::" + test_file.as_uri()
+    fetch_file(uri, download_dir)
+    assert (download_dir / filename).exists()
+
+
+def test_fetcher_with_fs(tmp_path):
+    """Test fetcher with a filesystem."""
+    filename = "important_data.nc"
+    test_file = tmp_path / filename
+    download_dir = tmp_path / "downloaded"
+    download_dir.mkdir()
+    with open(test_file, "w") as fd:
+        fd.write("very importand data.")
+    uri = test_file.as_uri()
+    fs = {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}
+    fetch_file(uri, download_dir, fs)
+    assert (download_dir / filename).exists()
+
+
+def test_fetcher_with_complex_uri_and_fs(tmp_path):
+    """Test fetcher with a complex uri and a filesystem."""
+    filename = "important_data.nc"
+    test_file = tmp_path / filename
+
+    download_dir = tmp_path / "downloaded"
+    download_dir.mkdir()
+
+    with open(test_file, "w") as fd:
+        fd.write("very important data.")
+
+    compressed_test_file = tmp_path / "important.zip"
+    with ZipFile(compressed_test_file, 'w') as myzip:
+        myzip.write(test_file)
+
+    uri = "zip://" + str(test_file) + "::" + compressed_test_file.as_uri()
+    fs = json.loads(fsspec.open(uri).fs.to_json())
+
+    returned_filename = fetch_file(str(test_file), download_dir, fs)
+    downloaded_filename = download_dir / filename
+    assert downloaded_filename.exists()
+    assert downloaded_filename == returned_filename
+
+
+def test_fetcher_with_complex_uri_and_fs_2(tmp_path):
+    """Test fetcher with a complex uri and a filesystem."""
+    filename = "important_data.nc"
+    test_file = tmp_path / filename
+
+    download_dir = tmp_path / "downloaded"
+    download_dir.mkdir()
+
+    with open(test_file, "w") as fd:
+        fd.write("very important data.")
+
+    compressed_test_file = tmp_path / "important.zip"
+    with ZipFile(compressed_test_file, 'w') as myzip:
+        myzip.write(test_file)
+
+    uri = "zip://" + str(test_file) + "::" + compressed_test_file.as_uri()
+    fs = json.loads(fsspec.open(uri).fs.to_json())
+
+    returned_filename = fetch_file("zip://" + str(test_file), download_dir, fs)
+    downloaded_filename = download_dir / filename
+    assert downloaded_filename.exists()
+    assert downloaded_filename == returned_filename
+
+
+def test_fetch_message_with_filesystem(tmp_path):
+    """Test fetch_message can use filesystem."""
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+
+    msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
+
+    sdr = tmp_path / "sdr"
+    sdr.mkdir()
+    with open(sdr / uid, "w") as fd:
+        fd.write("viirs data")
+
+    dest_path1 = tmp_path / "dest1"
+    dest_path1.mkdir()
+
+    fetch_from_message(Message(rawstr=msg), dest_path1)
+
+    assert (dest_path1 / uid).exists()
+
+
+def test_fetch_message_with_uri(tmp_path):
+    """Test fetch_message can use uri."""
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+
+    msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}"' '}')
+
+    sdr = tmp_path / "sdr"
+    sdr.mkdir()
+    with open(sdr / uid, "w") as fd:
+        fd.write("viirs data")
+
+    dest_path2 = tmp_path / "dest2"
+    dest_path2.mkdir()
+
+    fetch_from_message(Message(rawstr=msg), dest_path2)
+    assert (dest_path2 / uid).exists()
+
+
+def test_fetch_message_logs(tmp_path, caplog):
+    """Test fetch_message logs."""
+    caplog.set_level("INFO")
+
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+
+    msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}"' '}')
+
+    sdr = tmp_path / "sdr"
+    sdr.mkdir()
+    with open(sdr / uid, "w") as fd:
+        fd.write("viirs data")
+
+    dest_path2 = tmp_path / "dest2"
+    dest_path2.mkdir()
+
+    downloaded_file = fetch_from_message(Message(rawstr=msg), dest_path2)
+    assert str(downloaded_file) in caplog.text
+
+
+def test_subscribe_and_fetch(tmp_path):
+    """Test subscribe and fetch."""
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+
+    msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
+
+    sdr = tmp_path / "sdr"
+    sdr.mkdir()
+    with open(sdr / uid, "w") as fd:
+        fd.write("viirs data")
+
+    dest_path2 = tmp_path / "dest2"
+    dest_path2.mkdir()
+
+    subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
+    publisher_settings = dict(nameservers=False, port=1979)
+
+    with patched_publisher() as messages:
+        with patched_subscriber_recv([Message(rawstr=msg)]):
+            fetch_from_subscriber(dest_path2, subscriber_settings, publisher_settings)
+
+    assert (dest_path2 / uid).exists()
+    assert len(messages) == 1
+    message = Message(rawstr=messages[0])
+    expected_uri = f"file://{str(dest_path2)}/{uid}"
+    assert "path" not in message.data
+    assert "filesystem" not in message.data
+    assert message.data["uri"] == expected_uri
+
+
+def test_fetcher_cli(tmp_path):
+    """Test the fetcher command-line interface."""
+    config_file = tmp_path / "config.yaml"
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
+    publisher_settings = dict(nameservers=False, port=1979)
+    config = dict(destination=str(destination),
+                  subscriber_config=subscriber_settings,
+                  publisher_config=publisher_settings)
+
+    import yaml
+    with open(config_file, "w") as fd:
+        fd.write(yaml.dump(config))
+
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+
+    msg = ('pytroll://segment/viirs/l1b/ file a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
+
+    sdr = tmp_path / "sdr"
+    sdr.mkdir()
+    with open(sdr / uid, "w") as fd:
+        fd.write("viirs data")
+
+    with patched_publisher() as messages:
+        with patched_subscriber_recv([Message(rawstr=msg)]):
+
+            from trollmoves.fetcher import cli
+            cli([str(config_file)])
+
+    assert (destination / uid).exists()
+    assert len(messages) == 1
+    message = Message(rawstr=messages[0])
+    expected_uri = f"file://{str(destination)}/{uid}"
+    assert "path" not in message.data
+    assert "filesystem" not in message.data
+    assert message.data["uri"] == expected_uri
+
+
+def test_fetcher_does_not_try_to_fetch_non_file_messages(tmp_path):
+    """Test fetcher does not try to fetch non-file messages."""
+    config_file = tmp_path / "config.yaml"
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
+    publisher_settings = dict(nameservers=False, port=1979)
+    config = dict(destination=str(destination),
+                  subscriber_config=subscriber_settings,
+                  publisher_config=publisher_settings)
+
+    import yaml
+    with open(config_file, "w") as fd:
+        fd.write(yaml.dump(config))
+
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+
+    msg = ('pytroll://segment/viirs/l1b/ info a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
+
+    sdr = tmp_path / "sdr"
+    sdr.mkdir()
+    with open(sdr / uid, "w") as fd:
+        fd.write("viirs data")
+
+    with patched_publisher() as messages:
+        with patched_subscriber_recv([Message(rawstr=msg)]):
+
+            from trollmoves.fetcher import cli
+            cli([str(config_file)])
+
+    assert not (destination / uid).exists()
+    assert len(messages) == 0
+
+
+def test_fetcher_uses_log_config(tmp_path):
+    """Test fetcher uses log config."""
+    config_file = tmp_path / "config.yaml"
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
+    publisher_settings = dict(nameservers=False, port=1979)
+    config = dict(destination=str(destination),
+                  subscriber_config=subscriber_settings,
+                  publisher_config=publisher_settings)
+
+    import yaml
+    with open(config_file, "w") as fd:
+        fd.write(yaml.dump(config))
+
+    uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
+
+    msg = ('pytroll://segment/viirs/l1b/ info a001673@c22519.ad.smhi.se 2024-04-19T11:35:00.487388 v1.01 '
+           'application/json {"sensor": "viirs", '
+           f'"uid": "{uid}", "uri": "file://{str(tmp_path)}/sdr/{uid}", "path": "{str(tmp_path)}/sdr/{uid}", '
+           '"filesystem": {"cls": "fsspec.implementations.local.LocalFileSystem", "protocol": "file", "args": []}}')
+
+    sdr = tmp_path / "sdr"
+    sdr.mkdir()
+    with open(sdr / uid, "w") as fd:
+        fd.write("viirs data")
+
+    log_config_file = tmp_path / "log_config.yaml"
+    handler_name = "console123"
+    log_config = {
+        "version": 1,
+        "handlers": {
+            handler_name: {
+                "class": "logging.StreamHandler",
+                "level": "INFO",
+            },
+        },
+        "loggers": {
+            "": {
+                "level": "INFO",
+                "handlers": [handler_name],
+            },
+        },
+    }
+    with open(log_config_file, "w") as fd:
+        fd.write(yaml.dump(log_config))
+
+    with patched_publisher():
+        with patched_subscriber_recv([Message(rawstr=msg)]):
+
+            from trollmoves.fetcher import cli
+            cli([str(config_file), "-c", str(log_config_file)])
+
+    root = logging.getLogger()
+    assert len(root.handlers) == 1
+    assert root.handlers[0].name == handler_name


### PR DESCRIPTION
This PR adds a pytroll-fetcher script and functionality to download files received through messages, and documentations pages for trollmoves to be hosted on readthedocs.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
