### PR TITLE
Add logging to fetcher

### DIFF
--- a/trollmoves/fetcher.py
+++ b/trollmoves/fetcher.py
@@ -104,11 +104,13 @@ def fetch_from_subscriber(destination, subscriber_config, publisher_config):
             for message in sub.recv():
                 if message.type != "file":
                     continue
+                logger.debug(f"Fetching from {str(message)}")
                 downloaded_file = fetch_from_message(message, destination)
                 message.data.pop("filesystem", None)
                 message.data.pop("path", None)
                 message.data["uri"] = downloaded_file.as_uri()
                 pub.send(str(message))
+                logger.debug(f"Published {str(message)}")
 
 
 def cli(args=None):

--- a/trollmoves/tests/test_fetcher.py
+++ b/trollmoves/tests/test_fetcher.py
@@ -141,7 +141,7 @@ def test_fetch_message_with_uri(tmp_path):
 
 def test_fetch_message_logs(tmp_path, caplog):
     """Test fetch_message logs."""
-    caplog.set_level("INFO")
+    caplog.set_level("DEBUG")
 
     uid = "IVCDB_j02_d20240419_t1114110_e1115356_b07465_c20240419113435035578_cspp_dev.h5"
     sdr_file = tmp_path / "sdr" / uid
@@ -153,8 +153,15 @@ def test_fetch_message_logs(tmp_path, caplog):
     dest_path2 = tmp_path / "dest2"
     dest_path2.mkdir()
 
-    downloaded_file = fetch_from_message(Message(rawstr=msg), dest_path2)
-    assert str(downloaded_file) in caplog.text
+    subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
+    publisher_settings = dict(nameservers=False, port=1979)
+
+    with patched_subscriber_recv([Message(rawstr=msg)]):
+        fetch_from_subscriber(dest_path2, subscriber_settings, publisher_settings)
+
+    assert str(msg) in caplog.text
+    assert str(dest_path2 / uid) in caplog.text
+    assert "Published pytroll://" in caplog.text
 
 
 def test_subscribe_and_fetch(tmp_path):

--- a/trollmoves/tests/test_fetcher.py
+++ b/trollmoves/tests/test_fetcher.py
@@ -156,12 +156,13 @@ def test_fetch_message_logs(tmp_path, caplog):
     subscriber_settings = dict(nameserver=False, addresses=["ipc://bla"])
     publisher_settings = dict(nameservers=False, port=1979)
 
-    with patched_subscriber_recv([Message(rawstr=msg)]):
-        fetch_from_subscriber(dest_path2, subscriber_settings, publisher_settings)
+    with patched_publisher() as messages:
+        with patched_subscriber_recv([Message(rawstr=msg)]):
+            fetch_from_subscriber(dest_path2, subscriber_settings, publisher_settings)
 
     assert str(msg) in caplog.text
     assert str(dest_path2 / uid) in caplog.text
-    assert "Published pytroll://" in caplog.text
+    assert f"Published {messages[0]}" in caplog.text
 
 
 def test_subscribe_and_fetch(tmp_path):


### PR DESCRIPTION
This PR add two debug messages to fetcher, one on receiving a message, the other one on publishing.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 