### PR TITLE
Sanitize connection settings when using S3Mover

### DIFF
--- a/trollmoves/movers.py
+++ b/trollmoves/movers.py
@@ -514,11 +514,15 @@ class S3Mover(Mover):
 
     """
 
+    def __init__(self, origin, destination, attrs=None, backup_targets=None):
+        """Initialize the S3Mover."""
+        super().__init__(origin, destination, attrs, backup_targets)
+        self._sanitize_attrs()
+
     def copy(self):
         """Copy the file to a bucket."""
         if S3FileSystem is None:
             raise ImportError("S3Mover requires 's3fs' to be installed.")
-        self._sanitize_attrs()
         s3 = S3FileSystem(**self.attrs)
         destination_file_path = self._get_destination()
         LOGGER.debug('destination_file_path = %s', destination_file_path)

--- a/trollmoves/tests/test_movers.py
+++ b/trollmoves/tests/test_movers.py
@@ -23,13 +23,12 @@
 """Test the movers."""
 
 import os
-from unittest.mock import patch
-from urllib.parse import urlunparse
-from urllib.parse import urlparse
-import yaml
 from contextlib import contextmanager
+from unittest.mock import patch
+from urllib.parse import urlparse, urlunparse
 
 import pytest
+import yaml
 
 ORIGIN_FILENAME = "filename.ext"
 
@@ -139,6 +138,17 @@ def test_s3_copy_file_to_base(S3FileSystem):
     s3_mover.copy()
 
     S3FileSystem.return_value.put.assert_called_once_with(ORIGIN, "data-bucket/" + ORIGIN_FILENAME)
+
+
+@patch('trollmoves.movers.S3FileSystem')
+def test_s3_attrs_are_sanitized(S3FileSystem):
+    """Test that only accepted attrs are passed to S3Filesystem."""
+    attrs = {"ssh_key_filename": "should_be_removed", "endpoint_url": "should_be_included"}
+    s3_mover = _get_s3_mover(ORIGIN, "s3://data-bucket/", **attrs)
+    s3_mover.copy()
+
+    expected_attrs = {"endpoint_url": "should_be_included"}
+    S3FileSystem.assert_called_once_with(**expected_attrs)
 
 
 @patch('trollmoves.movers.S3FileSystem')


### PR DESCRIPTION
In https://github.com/pytroll/trollmoves/commit/b0570dcde2960a6d0ebb9a1a3d156e5de2795d97 I introduced a bug that triggers

```
AioSession.__init__() got an unexpected keyword argument 'ssh_key_filename'
```

when transfer is attempted to S3 object storage.

This PR adds connection parameter sanitation that only allows kwargs that are listed in `s3fs.S3FileSystem` docstring.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
