### PR TITLE
Make it configurable what kind of file time modes should be used ehn removing files

### DIFF
--- a/trollmoves/filescleaner.py
+++ b/trollmoves/filescleaner.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025 Pytroll Developers
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utility functions for cleaning files and directories."""
+
+
+import datetime as dt
+import logging
+import os
+from glob import glob
+
+LOGGER = logging.getLogger("__name__")
+
+
+try:
+    from posttroll.message import Message
+except ImportError:
+    def Message(*args, **kwargs):
+        """Fake message object in case posttroll isn't installed."""
+        del args, kwargs
+
+
+class FilesCleaner():
+    """Files cleaner class to accomodate cleaning of files acording to configured rules."""
+
+    def __init__(self, publisher, section, info, dry_run=True):
+        """Initialize the class."""
+        self.pub = publisher
+        self.section = section
+        self.info = info
+        self.dry_run = dry_run
+        self.st_time = self.info.get('st_time', 'st_ctime')
+
+    def clean_dir(self, ref_time, pathname):
+        """Clean up a directory."""
+        section_files = 0
+        section_size = 0
+        LOGGER.info("Cleaning %s", pathname)
+        flist = glob(pathname)
+
+        for filename in flist:
+            if not os.path.exists(filename):
+                continue
+            try:
+                stat = os.lstat(filename)
+            except OSError:
+                LOGGER.warning("Couldn't lstat path=%s", str(filename))
+                continue
+
+            if dt.datetime.fromtimestamp(stat.__getattribute__(self.st_time), dt.timezone.utc) < ref_time:
+                was_removed = False
+                if not self.dry_run:
+                    was_removed = self.remove_file(filename)
+                else:
+                    LOGGER.debug("Would remove %s", filename)
+                if was_removed:
+                    section_files += 1
+                    section_size += stat.st_size
+
+        return (section_size, section_files)
+
+    def clean_section(self):
+        """Clean up according to the configuration section."""
+        section_files = 0
+        section_size = 0
+        base_dir = self.info.get("base_dir", "")
+        if not os.path.exists(base_dir):
+            LOGGER.warning("Path %s missing, skipping section %s",
+                           base_dir, self.section)
+            return (section_size, section_files)
+        LOGGER.info("Cleaning in %s", base_dir)
+        templates = (item.strip() for item in self.info["templates"].split(","))
+        kws = {}
+        for key in ["days", "hours", "minutes", "seconds"]:
+            try:
+                kws[key] = int(self.info[key])
+            except KeyError:
+                pass
+        ref_time = dt.datetime.now(dt.timezone.utc) - dt.timedelta(**kws)
+
+        for template in templates:
+            pathname = os.path.join(base_dir, template)
+            size, num_files = self.clean_dir(ref_time, pathname)
+            section_files += num_files
+            section_size += size
+
+        return (section_size, section_files)
+
+    def remove_file(self, filename):
+        """Remove one file or directory."""
+        try:
+            if os.path.isdir(filename):
+                if not os.listdir(filename):
+                    os.rmdir(filename)
+                else:
+                    LOGGER.info("%s not empty.", filename)
+            else:
+                os.remove(filename)
+                msg = Message("/deletion", "del", {"uri": filename})
+                self.pub.send(str(msg))
+                LOGGER.debug("Removed %s", filename)
+        except FileNotFoundError:
+            LOGGER.debug("File already removed.")
+        except OSError as err:
+            LOGGER.warning("Can't remove %s: %s", filename,
+                           str(err))
+            return False
+        return True

--- a/trollmoves/tests/conftest.py
+++ b/trollmoves/tests/conftest.py
@@ -1,5 +1,24 @@
 """The conftest module to set up pytest."""
 
+import datetime as dt
+import os
+
+import pytest
+
+TEST_BASIC_FILESCLEANER_CONFIG_FILENAME = "remove_it.cfg"
+TEST_BASIC_FILESCLEANER_CONFIG = """
+[DEFAULT]
+mailhost=localhost
+to=some_users@xxx.yy
+subject=Cleanup Error on {hostname}
+
+
+[mytest_files1]
+base_dir=/san1
+templates=polar_in/sentinel3/olci/lvl1/*/*,polar_in/sentinel3/olci/lvl1/*
+hours=3
+"""
+
 
 def pytest_collection_modifyitems(items):
     """Modifiy test items in place to ensure test modules run in a given order."""
@@ -13,3 +32,49 @@ def pytest_collection_modifyitems(items):
             it for it in sorted_items if module_mapping[it] == module
         ]
     items[:] = sorted_items
+
+
+@pytest.fixture
+def fake_config_file(tmp_path):
+    """Create a fake configuration file."""
+    file_path = tmp_path / TEST_BASIC_FILESCLEANER_CONFIG_FILENAME
+    with open(file_path, 'w') as fpt:
+        fpt.write(TEST_BASIC_FILESCLEANER_CONFIG)
+
+    yield file_path
+
+
+@pytest.fixture
+def fake_file_structure(tmp_path):
+    """Create some fake files in a fake directory structure."""
+    data_dir = tmp_path / "mydata" / "geo_out"
+    data_dir.mkdir(parents=True)
+
+    # Create some empty files
+    files = ["a.txt", "b.txt", "c.csv"]
+    for fname in files:
+        (data_dir / fname).touch()
+
+    data_subdir1 = data_dir / "level2"
+    data_subdir1.mkdir(parents=True)
+    data_subdir2 = data_dir / "imagery"
+    data_subdir2.mkdir(parents=True)
+
+    files = ["a.nc", "b.nc", "c.h5"]
+    for fname in files:
+        (data_subdir1 / fname).touch()
+
+    six_hours_ago = dt.datetime.now(dt.UTC) - dt.timedelta(hours=6)
+
+    oldfile = (data_subdir1 / 'b.nc')
+    os.utime(oldfile, (six_hours_ago.timestamp(), six_hours_ago.timestamp()))
+
+    files = ["a.png", "b.png", "c.tif"]
+    for fname in files:
+        (data_subdir2 / fname).touch()
+
+    eight_hours_ago = dt.datetime.now(dt.UTC) - dt.timedelta(hours=8)
+    oldfile = (data_subdir2 / 'b.png')
+    os.utime(oldfile, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
+
+    return data_dir, data_subdir1, data_subdir2

--- a/trollmoves/tests/test_get_config.py
+++ b/trollmoves/tests/test_get_config.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025 Pytroll Developers
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unittesting the reading and extraction of clean configurations."""
+
+
+from configparser import RawConfigParser
+
+
+def test_read_config_params(fake_config_file):
+    """Test reading configuration from a config file."""
+    conf = RawConfigParser()
+    conf.read(fake_config_file)
+
+    info = dict(conf.items('DEFAULT'))
+    assert info == {'mailhost': 'localhost', 'to': 'some_users@xxx.yy', 'subject': 'Cleanup Error on {hostname}'}
+
+    info = dict(conf.items('mytest_files1'))
+    assert info == {'mailhost': 'localhost', 'to': 'some_users@xxx.yy', 'subject': 'Cleanup Error on {hostname}', 'base_dir': '/san1', 'templates': 'polar_in/sentinel3/olci/lvl1/*/*,polar_in/sentinel3/olci/lvl1/*', 'hours': '3'}  # noqa

--- a/trollmoves/tests/test_remove_files.py
+++ b/trollmoves/tests/test_remove_files.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025 Pytroll Developers
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unittests for the utilities used to removing files from the remove_it script."""
+
+
+import pytest
+
+from trollmoves.filescleaner import FilesCleaner
+
+
+class FakePublisher():
+    """Implements a Fake Publisher for testing."""
+
+    def __init__(self):
+        """Initialize the class."""
+        pass
+
+    def send(self, msg):
+        """Fake send message."""
+        print(msg)
+
+
+def test_remove_files_default(fake_file_structure):
+    """Test remove files - using default st_ctime as criteria."""
+    pub = FakePublisher()
+
+    dir_base, sub_dir1, sub_dir2 = fake_file_structure
+
+    basedir = str(dir_base)
+    subdir1 = sub_dir1.name
+    subdir2 = sub_dir2.name
+
+    section = 'mytest_files1'
+    info = {'mailhost': 'localhost',
+            'to': 'some_users@xxx.yy',
+            'subject': 'Cleanup Error on {hostname}',
+            'base_dir': f'{basedir}',
+            'templates': f'{subdir1}/*,{subdir2}/*.png',
+            'hours': '3'}
+
+    fcleaner = FilesCleaner(pub, section, info, dry_run=False)
+    size, num_files = fcleaner.clean_section()
+
+    assert (dir_base / "a.txt").exists()
+    assert (dir_base / "b.txt").exists()
+    assert (dir_base / "c.csv").exists()
+    assert (sub_dir1 / "a.nc").exists()
+    assert (sub_dir1 / "b.nc").exists()
+    assert (sub_dir1 / "c.h5").exists()
+    assert (sub_dir2 / "a.png").exists()
+    assert (sub_dir2 / "b.png").exists()
+    assert (sub_dir2 / "c.tif").exists()
+
+
+@pytest.mark.parametrize("hours, expected_files_removed",
+                         [(3,
+                           ("b.nc", "b.png")),
+                          (9,
+                           ())
+                          ]
+                         )
+def test_remove_files_access_time(fake_file_structure, hours, expected_files_removed):
+    """Test remove files."""
+    pub = FakePublisher()
+    dir_base, sub_dir1, sub_dir2 = fake_file_structure
+
+    basedir = str(dir_base)
+    subdir1 = sub_dir1.name
+    subdir2 = sub_dir2.name
+
+    section = 'mytest_files1'
+    info = {'mailhost': 'localhost',
+            'to': 'some_users@xxx.yy',
+            'subject': 'Cleanup Error on {hostname}',
+            'base_dir': f'{basedir}',
+            'st_time': 'st_atime',
+            'templates': f'{subdir1}/*,{subdir2}/*.png',
+            'hours': f'{hours}'}
+
+    fcleaner = FilesCleaner(pub, section, info, dry_run=False)
+    size, num_files = fcleaner.clean_section()
+
+    filepaths = [(sub_dir1 / "a.nc"),
+                 (sub_dir1 / "b.nc"),
+                 (sub_dir1 / "c.h5"),
+                 (sub_dir2 / "a.png"),
+                 (sub_dir2 / "b.png"),
+                 (sub_dir2 / "c.tif")]
+
+    fpaths_copy = filepaths.copy()
+    for fpath in fpaths_copy:
+        for fname in expected_files_removed:
+            if fname == fpath.name:
+                assert not fpath.exists()
+                filepaths.remove(fpath)
+
+    for fpath in filepaths:
+        assert fpath.exists()


### PR DESCRIPTION
This PR adds the options to controll waht kind of file time modes (`st_ctime`, st_atime` ot `st_mtime`) should be used when cleaning files using the `remove_it.py` script.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
