### PR TITLE
Fix posttroll notifier not to return a tuple

### DIFF
--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -731,7 +731,6 @@ class Chain:
             notifier_builder = _get_notifier_builder(use_polling, self.config)
 
         self.function_to_run = partial(function_to_run_on_matching_files, chain_config=self.config)
-
         self.notifier = notifier_builder(self.function_to_run)
 
     def start(self):
@@ -887,7 +886,7 @@ def create_posttroll_notifier(function_to_run, config):
     """Create a notifier listening to posttroll messages from *attrs*."""
     listener = Listener(function_to_run, config)
 
-    return listener, None
+    return listener
 
 
 def _disable_removed_chains(chains, new_chains):

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -125,7 +125,13 @@ def test_create_posttroll_notifier():
     chain = Chain("some_chain", config)
     function_to_run = MagicMock()
     # assert no crash
-    chain.create_notifier(notifier_builder=None, use_polling=True, function_to_run_on_matching_files=function_to_run)
+    from posttroll.testing import patched_subscriber_recv
+    with patched_subscriber_recv(["hello"]):
+        chain.create_notifier(notifier_builder=None,
+                              use_polling=True,
+                              function_to_run_on_matching_files=function_to_run)
+        chain.start()
+        chain.stop()
 
 
 def test_handler_does_not_dispatch_files_not_matching_pattern():


### PR DESCRIPTION
For some reason, this was an undetected error for quite a while...

 - [x] Closes #218  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
