### PR TITLE
Use Posttroll socket functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "netifaces-plus",
-    "posttroll>=1.5.1",
+    "posttroll>=1.13.1",
     "pyyaml",
     "pyzmq",
     "trollsift",

--- a/trollmoves/client.py
+++ b/trollmoves/client.py
@@ -14,7 +14,7 @@ from contextlib import suppress
 from threading import Event, Lock, Thread
 from urllib.parse import urlparse, urlunparse
 
-from posttroll import get_context
+from posttroll.backends.zmq.socket import set_up_client_socket
 from posttroll.message import Message, MessageError
 from posttroll.publisher import create_publisher_from_dict_config
 from posttroll.subscriber import Subscriber
@@ -925,8 +925,7 @@ class PushRequester:
 
     def connect(self):
         """Connect to the server."""
-        self._socket = get_context().socket(REQ)
-        self._socket.connect(self._reqaddress)
+        self._socket = set_up_client_socket(REQ, self._reqaddress)
         self._poller.register(self._socket, POLLIN)
 
     def stop(self):

--- a/trollmoves/mirror.py
+++ b/trollmoves/mirror.py
@@ -137,7 +137,7 @@ class MirrorRequestManager(RequestManager):
 
     def __init__(self, port, attrs):
         """Set up this mirror request manager."""
-        RequestManager.__init__(self, port, attrs)
+        super().__init__(port, attrs)
         self._deleter = MirrorDeleter(attrs)
 
     def push(self, message):

--- a/trollmoves/move_it_req.py
+++ b/trollmoves/move_it_req.py
@@ -6,6 +6,7 @@ import argparse
 import time
 
 import zmq
+from posttroll.backends.zmq.socket import close_socket, set_up_client_socket
 from posttroll.message import Message
 
 REQUEST_TIMEOUT = 4500
@@ -78,11 +79,8 @@ def run(args):
 
     req_data = get_request_data(args)
 
-    context = zmq.Context(1)
-
     print("Connecting to '%s' ..." % args.server)
-    client = context.socket(zmq.REQ)
-    client.connect(args.server)
+    client = set_up_client_socket(zmq.REQ, args.server)
 
     poll = zmq.Poller()
     poll.register(client, zmq.POLLIN)
@@ -110,17 +108,15 @@ def run(args):
                 else:
                     print("No response from server, retrying ...")
                     # Socket is confused. Close and remove it.
-                    client.setsockopt(zmq.LINGER, 0)
-                    client.close()
                     poll.unregister(client)
+                    close_socket(client)
                     retries_left -= 1
                     if retries_left == 0:
                         print("Server seems to be offline, abandoning")
                         break
                     print("Reconnecting and resending (%s)" % request)
                     # Create new connection
-                    client = context.socket(zmq.REQ)
-                    client.connect(args.server)
+                    client = set_up_client_socket(zmq.REQ, args.server)
                     poll.register(client, zmq.POLLIN)
                     client.send(request)
             if args.spam is not None:
@@ -130,7 +126,7 @@ def run(args):
     except KeyboardInterrupt:
         pass
     finally:
-        context.term()
+        close_socket(client)
 
 
 def main():

--- a/trollmoves/server.py
+++ b/trollmoves/server.py
@@ -19,7 +19,7 @@ from queue import Empty, Queue
 from threading import Lock, Thread
 from urllib.parse import urlparse
 
-from posttroll import get_context
+from posttroll.backends.zmq.socket import close_socket, set_up_client_socket, set_up_server_socket
 from posttroll.message import Message, MessageError
 from posttroll.publisher import get_own_ip
 from posttroll.subscriber import Subscribe
@@ -67,12 +67,10 @@ class RequestManager(Thread):
         self._deleter = Deleter(attrs)
 
     def _set_out_socket(self):
-        self.out_socket = get_context().socket(ROUTER)
-        self.out_socket.bind("tcp://*:" + str(self.port))
+        self.out_socket, _, _ = set_up_server_socket(ROUTER, "tcp://*:" + str(self.port))
 
     def _set_in_socket(self):
-        self.in_socket = get_context().socket(PULL)
-        self.in_socket.bind("inproc://replies" + str(self.port))
+        self.in_socket, _, _ = set_up_server_socket(PULL, "inproc://replies" + str(self.port))
 
     def _set_station(self):
         try:
@@ -201,12 +199,13 @@ class RequestManager(Thread):
 
     def _send_multipart_reply(self, reply, address):
         LOGGER.debug("Response: %s", str(reply))
-        in_socket = get_context().socket(PUSH)
-        in_socket.connect("inproc://replies" + str(self.port))
+        in_socket = set_up_client_socket(PUSH, "inproc://replies" + str(self.port))
         try:
             in_socket.send_multipart([address, b"", str(reply)])
         except TypeError:
             in_socket.send_multipart([address, b"", bytes(str(reply), "utf-8")])
+        finally:
+            close_socket(in_socket)
 
     def run(self):
         """Run request manager."""

--- a/trollmoves/tests/test_mirror.py
+++ b/trollmoves/tests/test_mirror.py
@@ -2,11 +2,11 @@
 
 import unittest
 from tempfile import NamedTemporaryFile
-from unittest.mock import patch
+from unittest.mock import DEFAULT, patch
 
 import pytest
 
-from trollmoves.mirror import MirrorRequestManager, MoveItMirror, parse_args
+from trollmoves.mirror import MoveItMirror, parse_args
 
 
 class TestMirrorDeleter(unittest.TestCase):

--- a/trollmoves/tests/test_mirror.py
+++ b/trollmoves/tests/test_mirror.py
@@ -32,7 +32,7 @@ class TestMirrorRequestManager(unittest.TestCase):
         attrs = {"origin": "here"}
 
         with patch("trollmoves.mirror.MirrorDeleter", autospec=True) as md:
-            with patch("trollmoves.mirror.RequestManager", autospec=True):
+            with patch("trollmoves.server.RequestManager.__init__", return_value=None):
                 from trollmoves.mirror import MirrorRequestManager
                 MirrorRequestManager("some_port", attrs)  # noqa
                 assert md.call_args[0][0] == attrs

--- a/trollmoves/tests/test_mirror.py
+++ b/trollmoves/tests/test_mirror.py
@@ -2,7 +2,7 @@
 
 import unittest
 from tempfile import NamedTemporaryFile
-from unittest.mock import DEFAULT, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -29,11 +29,11 @@ class TestMirrorRequestManager(unittest.TestCase):
 
     def test_deleter_gets_attrs(self):
         """Test that the deleter gets the right info on init."""
-        from trollmoves.mirror import MirrorRequestManager
         attrs = {"origin": "here"}
 
         with patch("trollmoves.mirror.MirrorDeleter", autospec=True) as md:
-            with patch.multiple("trollmoves.server", Poller=DEFAULT, get_context=DEFAULT):
+            with patch("trollmoves.mirror.RequestManager", autospec=True):
+                from trollmoves.mirror import MirrorRequestManager
                 MirrorRequestManager("some_port", attrs)  # noqa
                 assert md.call_args[0][0] == attrs
 

--- a/trollmoves/tests/test_server.py
+++ b/trollmoves/tests/test_server.py
@@ -312,7 +312,7 @@ class TestMoveItServer:
             mock_reload_config.assert_called_once()
 
 
-@patch("trollmoves.server.get_context")
+@patch("trollmoves.server.set_up_server_socket")
 @patch("trollmoves.server.Poller.poll")
 @patch("trollmoves.server.RequestManager._set_station")
 @patch("trollmoves.server.RequestManager._set_out_socket")
@@ -325,7 +325,7 @@ def test_requestmanager_run_valid_pytroll_message(patch_process_request,
                                                   patch_set_out_socket,
                                                   patch_set_station,
                                                   patch_poller,
-                                                  patch_get_context):
+                                                  patch_set_up_server_socket):
     """Test request manager run with valid address and payload."""
     from posttroll.message import _MAGICK
     from zmq import POLLIN
@@ -335,6 +335,7 @@ def test_requestmanager_run_valid_pytroll_message(patch_process_request,
                r"/test/1/2/3 info ras@hawaii 2008-04-11T22:13:22.123000 v1.01" +
                r' text/ascii "what' + r"'" + r's up doc"')
     address = b"tcp://192.168.10.8:37325"
+    patch_set_up_server_socket.return_value = MagicMock(), MagicMock(), MagicMock()
     patch_get_address_and_payload.return_value = address, payload
     port = 9876
     patch_poller.return_value = {"POLLIN": POLLIN}
@@ -344,7 +345,7 @@ def test_requestmanager_run_valid_pytroll_message(patch_process_request,
     patch_process_request.assert_called_once()
 
 
-@patch("trollmoves.server.get_context")
+@patch("trollmoves.server.set_up_server_socket")
 @patch("trollmoves.server.Poller.poll")
 @patch("trollmoves.server.RequestManager._set_station")
 @patch("trollmoves.server.RequestManager._set_out_socket")
@@ -355,7 +356,7 @@ def test_requestmanager_run_MessageError_exception(patch_validate_file_pattern,
                                                    patch_set_out_socket,
                                                    patch_set_station,
                                                    patch_poller,
-                                                   patch_get_context,
+                                                   patch_set_up_server_socket,
                                                    caplog):
     """Test request manager run with invalid payload causing a MessageError exception."""
     import logging
@@ -363,6 +364,7 @@ def test_requestmanager_run_MessageError_exception(patch_validate_file_pattern,
     from zmq import POLLIN
 
     from trollmoves.server import RequestManager
+    patch_set_up_server_socket.return_value = MagicMock(), MagicMock(), MagicMock()
     patch_get_address_and_payload.return_value = "address", "fake_payload"
     port = 9876
     patch_poller.return_value = {"POLLIN": POLLIN}


### PR DESCRIPTION
This thus allows trollmoves to use posttroll security features: zap handshake, white-listing and curve authentification

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
