### PR TITLE
Make sure never to delete configured base dir even if old

### DIFF
--- a/trollmoves/filescleaner.py
+++ b/trollmoves/filescleaner.py
@@ -56,17 +56,20 @@ class FilesCleaner():
         section_size = 0
         removed = []
 
-        for pathname in glob(pathname_template):
-            for dirpath, _dirnames, _ in os.walk(Path(pathname).parent, followlinks=True):
-                files_in_dir = glob(os.path.join(dirpath, Path(pathname_template).name))
+        base_path = Path(pathname_template).parent
+        pattern = Path(pathname_template).name
 
-                if len(files_in_dir) == 0:
-                    self._remove_empty_directory(dirpath)
+        for dirpath, _dirnames, _ in os.walk(base_path, followlinks=True):
+            files_in_dir = glob(os.path.join(dirpath, pattern))
 
-                s_size, s_files, removed_files = self.clean_files_and_dirs(files_in_dir, ref_time)
-                section_files += s_files
-                section_size += s_size
-                removed.extend(removed_files)
+            s_size, s_files, removed_files = self.clean_files_and_dirs(files_in_dir, ref_time)
+            section_files += s_files
+            section_size += s_size
+            removed.extend(removed_files)
+
+            # Do not remove the configured/base directory itself
+            if Path(dirpath) != base_path and not os.listdir(dirpath):
+                self._remove_empty_directory(dirpath)
 
         return (section_size, section_files, removed)
 

--- a/trollmoves/tests/conftest.py
+++ b/trollmoves/tests/conftest.py
@@ -102,3 +102,24 @@ def file_structure_with_some_old_files_and_empty_dir(tmp_path):
     os.utime(data_subdir2, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
 
     return data_dir, data_subdir1, data_subdir2
+
+
+@pytest.fixture
+def flat_file_structure_with_no_files(tmp_path):
+    """Create a flat directory structure with an old empty basedir."""
+    base_dir = tmp_path / "mydata"
+    base_dir.mkdir(parents=True)
+
+    files = ["old1.png", "old2.tiff"]
+    for fname in files:
+        (base_dir / fname).touch()
+
+    eight_hours_ago = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=8)
+    oldfile = (base_dir / "old1.png")
+    os.utime(oldfile, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
+    oldfile = (base_dir / "old2.tiff")
+    os.utime(oldfile, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
+    # Force the directory to be old as well:
+    os.utime(base_dir, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
+
+    return base_dir

--- a/trollmoves/tests/test_remove_files.py
+++ b/trollmoves/tests/test_remove_files.py
@@ -136,6 +136,32 @@ def test_remove_files_access_time_dryrun(file_structure_with_some_old_files, cap
     assert log_output2 in caplog.text
 
 
+def test_remove_old_files_but_not_basedir(flat_file_structure_with_no_files, caplog):
+    """Test remove old files in a base directory, but do not delete old base dir."""
+    pub = FakePublisher()
+    basedir = flat_file_structure_with_no_files
+
+    section = "mytest_files1"
+    info = {"mailhost": "localhost",
+            "to": "some_users@xxx.yy",
+            "subject": "Cleanup Error on {hostname}",
+            "base_dir": basedir,
+            "stat_time_method": "st_mtime",
+            "recursive": True,
+            "templates": f"{basedir}/*",
+            "hours": "6"}
+
+    with caplog.at_level(logging.WARNING):
+        fcleaner = FilesCleaner(pub, section, info, dry_run=False)
+        size, num_files, removed_files = fcleaner.clean_section()
+
+    assert size == 0
+    assert num_files == 2
+    assert len(removed_files) == 2
+    assert basedir.exists()
+    assert len(caplog.text) == 0
+
+
 def test_remove_files_path_missing(file_structure_with_some_old_files, caplog):
     """Test remove files in file structure with an empty directory."""
     pub = FakePublisher()


### PR DESCRIPTION
Using the `remove_it.py` script we have experienced that using the recursive flag to clean directory structures even the old and empty base directory gets deleted. This is an unwanted feature! This PR fixes this. So I added a new test, where I could reproduce this error with the old code. See the new unit test: `test_remove_old_files_but_not_basedir`.

NB! Code updated is in the `filescleaner.py` and thus should only impact the `remove_it.py` part of Trollmoves.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
