### PR TITLE
Handle cases with wildcards inside the path to the basedir-template

### DIFF
--- a/trollmoves/filescleaner.py
+++ b/trollmoves/filescleaner.py
@@ -56,20 +56,24 @@ class FilesCleaner():
         section_size = 0
         removed = []
 
-        base_path = Path(pathname_template).parent
-        pattern = Path(pathname_template).name
+        base_template = str(Path(pathname_template).parent)
+        file_pattern = Path(pathname_template).name
 
-        for dirpath, _dirnames, _ in os.walk(base_path, followlinks=True):
-            files_in_dir = glob(os.path.join(dirpath, pattern))
+        for base_dir in glob(base_template):
+            if not os.path.isdir(base_dir):
+                continue
 
-            s_size, s_files, removed_files = self.clean_files_and_dirs(files_in_dir, ref_time)
-            section_files += s_files
-            section_size += s_size
-            removed.extend(removed_files)
+            for dirpath, _dirnames, _ in os.walk(base_dir, followlinks=True):
+                files_in_dir = glob(os.path.join(dirpath, file_pattern))
 
-            # Do not remove the configured/base directory itself
-            if Path(dirpath) != base_path and not os.listdir(dirpath):
-                self._remove_empty_directory(dirpath)
+                s_size, s_files, removed_files = self.clean_files_and_dirs(files_in_dir, ref_time)
+                section_files += s_files
+                section_size += s_size
+                removed.extend(removed_files)
+
+                # Do not remove the configured/base directory itself
+                if Path(dirpath) != Path(base_dir) and not os.listdir(dirpath):
+                    self._remove_empty_directory(dirpath)
 
         return (section_size, section_files, removed)
 

--- a/trollmoves/filescleaner.py
+++ b/trollmoves/filescleaner.py
@@ -41,6 +41,7 @@ class FilesCleaner():
         self.recursive = self.info.get("recursive", False)
         self.stat_time_method = self.info.get("stat_time_method", "st_ctime")
 
+
     def clean_dir(self, ref_time, pathname_template, **kwargs):
         """Clean directory of files given a path name and a time threshold.
 
@@ -63,19 +64,54 @@ class FilesCleaner():
             if not os.path.isdir(base_dir):
                 continue
 
-            for dirpath, _dirnames, _ in os.walk(base_dir, followlinks=True):
-                files_in_dir = glob(os.path.join(dirpath, file_pattern))
+            s_size, s_files, removed_files = self._clean_recursive_base_dir(base_dir, file_pattern, ref_time)
 
-                s_size, s_files, removed_files = self.clean_files_and_dirs(files_in_dir, ref_time)
-                section_files += s_files
-                section_size += s_size
-                removed.extend(removed_files)
+            section_files += s_files
+            section_size += s_size
+            removed.extend(removed_files)
 
-                # Do not remove the configured/base directory itself
-                if Path(dirpath) != Path(base_dir) and not os.listdir(dirpath):
-                    self._remove_empty_directory(dirpath)
+        return section_size, section_files, removed
 
-        return (section_size, section_files, removed)
+
+    def _clean_recursive_base_dir(self, base_dir, file_pattern, ref_time):
+        """Clean matching files recursively below one base directory.
+
+        Empty subdirectories may be removed, but the base directory itself is
+        never removed.
+        """
+        section_files = 0
+        section_size = 0
+        removed = []
+
+        base_dir = Path(base_dir)
+
+        for dirpath, _dirnames, _filenames in os.walk(base_dir, followlinks=True):
+            dirpath = Path(dirpath)
+            files_in_dir = glob(str(dirpath / file_pattern))
+
+            s_size, s_files, removed_files = self.clean_files_and_dirs(files_in_dir, ref_time)
+
+            section_files += s_files
+            section_size += s_size
+            removed.extend(removed_files)
+
+            if dirpath != base_dir and self._is_empty_dir(dirpath):
+                self._remove_empty_directory(dirpath)
+
+        return section_size, section_files, removed
+
+
+    @staticmethod
+    def _is_empty_dir(path):
+        """Return True if path is an empty directory.
+
+        Using iterdir instead of glob will make sure dot files are also counted.
+        """
+        try:
+            return path.is_dir() and not any(path.iterdir())
+        except OSError:
+            return False
+
 
     def clean_files_and_dirs(self, filepaths, ref_time):
         """Clean files and directories defined by a list of file paths and a reference time."""
@@ -103,6 +139,7 @@ class FilesCleaner():
                     LOGGER.info(f"Would remove {str(filepath)}")
 
         return (section_size, section_files, removed)
+
 
     def clean_section(self):
         """Do the files cleaning given a list of directory paths and time thresholds.

--- a/trollmoves/tests/conftest.py
+++ b/trollmoves/tests/conftest.py
@@ -86,27 +86,27 @@ def file_structure_with_some_old_files_and_empty_dir(tmp_path):
     data_dir = tmp_path / "mydata" / "geo_out"
     data_dir.mkdir(parents=True)
 
-    data_subdir1 = data_dir / "imagery-1"
-    data_subdir1.mkdir(parents=True)
-    data_subdir2 = data_dir / "imagery-2"
-    data_subdir2.mkdir(parents=True)
-    data_subdir3 = data_dir / "empty_dir"
-    data_subdir3.mkdir(parents=True)
+    subdir1_old_png_file = data_dir / "imagery-1"
+    subdir1_old_png_file.mkdir(parents=True)
+    subdir2_old_tif_file = data_dir / "imagery-2"
+    subdir2_old_tif_file.mkdir(parents=True)
+    subdir3_empty = data_dir / "empty_dir"
+    subdir3_empty.mkdir(parents=True)
 
     files = ["a.png", "b.png", "c.tif"]
     for fname in files:
-        (data_subdir1 / fname).touch()
-        (data_subdir2 / fname).touch()
+        (subdir1_old_png_file / fname).touch()
+        (subdir2_old_tif_file / fname).touch()
 
     eight_hours_ago = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=8)
-    oldfile = (data_subdir1 / "b.png")
+    oldfile = (subdir1_old_png_file / "b.png")
     os.utime(oldfile, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
-    oldfile = (data_subdir2 / "c.tif")
+    oldfile = (subdir2_old_tif_file / "c.tif")
     os.utime(oldfile, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
     # Force the directory to be old as well:
-    os.utime(data_subdir3, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
+    os.utime(subdir3_empty, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
 
-    return data_dir, data_subdir1, data_subdir2, data_subdir3
+    return data_dir, subdir1_old_png_file, subdir2_old_tif_file, subdir3_empty
 
 
 @pytest.fixture

--- a/trollmoves/tests/conftest.py
+++ b/trollmoves/tests/conftest.py
@@ -86,22 +86,27 @@ def file_structure_with_some_old_files_and_empty_dir(tmp_path):
     data_dir = tmp_path / "mydata" / "geo_out"
     data_dir.mkdir(parents=True)
 
-    data_subdir1 = data_dir / "imagery"
+    data_subdir1 = data_dir / "imagery-1"
     data_subdir1.mkdir(parents=True)
-    data_subdir2 = data_dir / "empty_dir"
+    data_subdir2 = data_dir / "imagery-2"
     data_subdir2.mkdir(parents=True)
+    data_subdir3 = data_dir / "empty_dir"
+    data_subdir3.mkdir(parents=True)
 
     files = ["a.png", "b.png", "c.tif"]
     for fname in files:
         (data_subdir1 / fname).touch()
+        (data_subdir2 / fname).touch()
 
     eight_hours_ago = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=8)
     oldfile = (data_subdir1 / "b.png")
     os.utime(oldfile, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
+    oldfile = (data_subdir2 / "c.tif")
+    os.utime(oldfile, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
     # Force the directory to be old as well:
-    os.utime(data_subdir2, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
+    os.utime(data_subdir3, (eight_hours_ago.timestamp(), eight_hours_ago.timestamp()))
 
-    return data_dir, data_subdir1, data_subdir2
+    return data_dir, data_subdir1, data_subdir2, data_subdir3
 
 
 @pytest.fixture

--- a/trollmoves/tests/test_remove_files.py
+++ b/trollmoves/tests/test_remove_files.py
@@ -194,7 +194,7 @@ def test_remove_files_path_missing(file_structure_with_some_old_files, caplog):
 def test_remove_files_empty_dir_mtime(file_structure_with_some_old_files_and_empty_dir, caplog):
     """Test remove files."""
     pub = FakePublisher()
-    dir_base, sub_dir1, sub_dir2 = file_structure_with_some_old_files_and_empty_dir
+    dir_base, sub_dir1, _, sub_dir2 = file_structure_with_some_old_files_and_empty_dir
 
     basedir = str(dir_base)
     subdir1 = sub_dir1.name
@@ -220,10 +220,38 @@ def test_remove_files_empty_dir_mtime(file_structure_with_some_old_files_and_emp
     assert not sub_dir2.exists()
 
 
+def test_remove_files_using_wildcard_in_template_dirs(file_structure_with_some_old_files_and_empty_dir, caplog):
+    """Test remove files."""
+    pub = FakePublisher()
+    dir_base, sub_dir1, sub_dir2, sub_dir3 = file_structure_with_some_old_files_and_empty_dir
+
+    basedir = str(dir_base)
+
+    section = "mytest_files1"
+    info = {"mailhost": "localhost",
+            "to": "some_users@xxx.yy",
+            "subject": "Cleanup Error on {hostname}",
+            "base_dir": f"{basedir}",
+            "stat_time_method": "st_mtime",
+            "recursive": True,
+            "templates": f"{dir_base}/imagery-?/*",
+            "hours": "3"}
+
+    with caplog.at_level(logging.DEBUG):
+        fcleaner = FilesCleaner(pub, section, info, dry_run=False)
+        size, num_files, removed_files = fcleaner.clean_section()
+
+    log_output1 = f'Removed {(sub_dir1 / "b.png")}'
+    assert log_output1 in caplog.text
+    assert not (sub_dir1 / "b.png").exists()
+    assert num_files == 2
+    assert sub_dir3.exists()
+
+
 def test_remove_files_empty_dir_atime(file_structure_with_some_old_files_and_empty_dir, caplog):
     """Test remove files."""
     pub = FakePublisher()
-    dir_base, sub_dir1, sub_dir2 = file_structure_with_some_old_files_and_empty_dir
+    dir_base, sub_dir1, _, sub_dir2 = file_structure_with_some_old_files_and_empty_dir
 
     basedir = str(dir_base)
     subdir1 = sub_dir1.name


### PR DESCRIPTION
We realised there was a bug in the recently merged PR = https://github.com/pytroll/trollmoves/pull/241

The changes implemnted to `filescleaner.py` in https://github.com/pytroll/trollmoves/pull/241 fails to properly handle the cases when the configures base-dir template looks like this: "somedir/otherdirs-??/*.ext".

That was apprently not acptured by existing unit tests. This is now repaired and the code updated/fixed.



<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #242 
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
